### PR TITLE
Bogus 227 directory no longer required!

### DIFF
--- a/lib/DBD/Oracle/Troubleshooting/Macos.pod
+++ b/lib/DBD/Oracle/Troubleshooting/Macos.pod
@@ -82,15 +82,6 @@ Create a symlink from F<libclntsh.dylib.10.1> to F<libclntsh.dylib>:
 
 =item *
 
-The following directory is hardcoded into the Oracle Instant Client - god
-knows why - so we need to create and symlink it:
-
-  sudo mkdir -p /b/227/rdbms/
-  sudo cd /b/227/rdbms/
-  sudo ln -s /usr/oracle_instantclient/ lib
-
-=item *
-
 Update your environment to point to the libraries:
 
   export ORACLE_HOME=/usr/oracle_instantclient


### PR DESCRIPTION
Just built with the latest version of [Oracle Instant Client for OS X](http://www.oracle.com/technetwork/topics/intel-macsoft-096467.html) with 64-bit support, and it worked great. I did not need to create the bogus `/b/227` directory.
