### PR TITLE
Fix rt91698

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,12 @@ Revision history for DBD::Oracle
 {{$NEXT}}
   - promote 1.67_00 to stable.
 
+  [BUG FIXES]
+
+  - Fix RT91698. If you bound an output parameter to a scalar and
+    repeatedly called execute the memory allocated in your bound
+    scalar could increase each time. (Martin J. Evans)
+
 1.67_00   2013-11-05
 
   [BUG FIXES]
@@ -11,7 +17,7 @@ Revision history for DBD::Oracle
 
   [DOCUMENTATION]
   - POD typos (RT#88285, RT#88284, Gregor Herrman).
-  - Grooming of Hpux troubleshooting pod (GH#7, Martin J. Evans, 
+  - Grooming of Hpux troubleshooting pod (GH#7, Martin J. Evans,
     Yanick Champoux)
 
 1.66      2013-08-23

--- a/oci8.c
+++ b/oci8.c
@@ -1226,7 +1226,7 @@ dbd_phs_out(dvoid *octxp, OCIBind *bindp,
 				sv_setpv(sv,"");
 		}
 
-		*bufpp = SvGROW(sv, (size_t)(((phs->maxlen < 28) ? 28 : phs->maxlen)+1)/*for null*/);
+        *bufpp = SvGROW(sv, (size_t)(((phs->maxlen < 28) ? 28 : phs->maxlen)));
 		phs->alen = SvLEN(sv);	/* max buffer size now, actual data len later */
 
 	}


### PR DESCRIPTION
Repeatedly executing output bound params can cause the bound scalars to continually increase in size.

I wouldn't merge this right now. Best to see if the original reporter thinks it is fixed and give a few others a chance to test it in case I broke something else.

Martin
