### PR TITLE
Rewrite of DRCP session pooling to make it work as intended, various additional fixes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,7 @@ use Pod::Usage;
 # For those not using Dynamic loading this means building a
 # new static perl in the DBI directory by saying 'make perl'
 # and then using _that_ perl to make this one.
-use DBI 1.51;
+use DBI 1.623;
 use DBI::DBD;	# DBD creation tools
 
 
@@ -45,7 +45,7 @@ my %opts = (
     NAME => 'DBD::Oracle',
     VERSION_FROM => 'lib/DBD/Oracle.pm',
     PREREQ_PM => { "Test::Simple" => 0.90, # actually Test::More pkg in T::S dist
-                   "DBI"          => 1.51},
+                   "DBI"          => 1.623},
     OBJECT => '$(O_FILES)',
     DEFINE => '',
     DIR  => [],
@@ -56,8 +56,8 @@ my %opts = (
 	COMPRESS	=> 'gzip -v9', SUFFIX => 'gz',
     },
     META_MERGE => {
-       configure_requires => { "DBI" => '1.51' },
-       build_requires => {"DBI" => '1.51',
+       configure_requires => { "DBI" => '1.623' },
+       build_requires => {"DBI" => '1.623',
                           "ExtUtils::MakeMaker" => 0,
                           "Test::Simple" => '0.90'},
        resources => {
@@ -81,7 +81,7 @@ $eumm =~ tr/_//d;
 if ($eumm >= 5.43) {
     $opts{AUTHOR} = 'Tim Bunce (dbi-users@perl.org)';
     $opts{ABSTRACT_FROM} = 'lib/DBD/Oracle.pm';
-    $opts{PREREQ_PM} = { DBI => 1.51 };
+    $opts{PREREQ_PM} = { DBI => 1.623 };
     $opts{CAPI} = 'TRUE' if $Config{archname} =~ /-object\b/i;
 }
 

--- a/Oracle.h
+++ b/Oracle.h
@@ -60,6 +60,7 @@
 
 void	dbd_init _((dbistate_t *dbistate));
 void	dbd_init_oci_drh _((imp_drh_t * imp_drh));
+void	dbd_dr_destroy _((SV *drh, imp_drh_t *imp_drh));
 
 int	 dbd_db_login  _((SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *user, char *pwd));
 int	 dbd_db_do _((SV *sv, char *statement));

--- a/Oracle.xs
+++ b/Oracle.xs
@@ -712,6 +712,11 @@ init_oci(drh)
 	dbd_init_oci(DBIS) ;
 	dbd_init_oci_drh(imp_drh) ;
 
-
-
-
+void
+DESTROY(drh)
+    SV *        drh
+    PPCODE:
+    /* keep in sync with default DESTROY in DBI.xs (currently there is no dr default) */
+    D_imp_drh(drh);
+    ST(0) = &PL_sv_yes;
+    dbd_dr_destroy(drh, imp_drh);

--- a/README
+++ b/README
@@ -43,7 +43,7 @@ DBD::Oracle  --  an Oracle interface for Perl 5.
     Build, test and install Perl 5 (at least 5.6.1)
     It is very important to TEST it and INSTALL it!
 
-    Build, test and install the DBI module (at least DBI 1.51).
+    Build, test and install the DBI module (at least DBI 1.623).
     It is very important to TEST it and INSTALL it!
 
     Remember to *read* the DBI README file and this one CAREFULLY!

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -844,6 +844,8 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 		if (imp_dbh->using_drcp) { /* connect using a DRCP */
 			OCIAuthInfo *authp;
 			ub4   purity = OCI_ATTR_PURITY_SELF;
+			OraText *rettag;
+			ub4 rettagl;
 			/* pool Default values */
 			if (!imp_dbh->pool_min )
 				imp_dbh->pool_min = 0;
@@ -930,7 +932,7 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 
 			OCISessionGet_log_stat(imp_dbh, imp_dbh->envhp, imp_dbh->errhp, &imp_dbh->svchp, authp,
 						pool->pool_name, (ub4)strlen((char *)pool->pool_name),
-						imp_dbh->session_tag, (ub4)strlen((char *)imp_dbh->session_tag), &imp_dbh->session_tag_found, status);
+						imp_dbh->session_tag, (ub4)strlen((char *)imp_dbh->session_tag), &rettag, &rettagl, &imp_dbh->session_tag_found, status);
 			if (status != OCI_SUCCESS) {
 				oci_error(dbh, imp_dbh->errhp, status, "OCISessionGet");
 				OCIHandleFree_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO, status);

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4215,6 +4215,7 @@ dbd_st_destroy(SV *sth, imp_sth_t *imp_sth)
 	int i;
 	sword status;
 	dTHX ;
+	D_imp_dbh_from_sth;
 
 	/*  Don't free the OCI statement handle for a nested cursor. It will
 		be reused by Oracle on the next fetch. Indeed, we never
@@ -4225,8 +4226,7 @@ dbd_st_destroy(SV *sth, imp_sth_t *imp_sth)
 
 	/* if we are using a scrolling cursor we should get rid of the
 	cursor by fetching row 0 */
-
-	if (imp_sth->exe_mode==OCI_STMT_SCROLLABLE_READONLY){
+	if (imp_sth->exe_mode==OCI_STMT_SCROLLABLE_READONLY && DBIc_ACTIVE(imp_dbh)) {
 		OCIStmtFetch_log_stat(imp_sth, imp_sth->stmhp, imp_sth->errhp, 0,OCI_FETCH_NEXT,0,  status);
 	}
 

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -98,7 +98,7 @@ oci_error_get(imp_xxh_t *imp_xxh,
                           what ? what : "<NULL>", (long)recno,
                           (eg_status==OCI_SUCCESS) ? "ok" : oci_status_name(eg_status),
                           status, (long)eg_errcode, errbuf);
-			errcode = eg_errcode;
+		errcode = eg_errcode;
 		sv_catpv(errstr, (char*)errbuf);
 		if (*(SvEND(errstr)-1) == '\n')
 			--SvCUR(errstr);
@@ -407,7 +407,7 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 	if (DBD_ATTRIB_TRUE(attr,"ora_drcp",8,svp))
 		imp_dbh->using_drcp = 1;
 
-	/* some connection pool atributes  */
+	/* some connection pool attributes  */
 
 	if ((svp=DBD_ATTRIB_GET_SVP(attr, "ora_drcp_class", 14)) && SvOK(*svp)) {
 		STRLEN  svp_len;
@@ -501,7 +501,7 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 		shared_dbh_len 	= SvCUR((shared_dbh_ssv -> sv)) ;
 
 		if (shared_dbh_len > 0 && shared_dbh_len != sizeof (imp_dbh_t))
-			croak ("Invalid value for ora_dbh_dup") ;
+			croak ("Invalid value for ora_dbh_share") ;
 
 		if (shared_dbh_len == sizeof (imp_dbh_t)) {
 		/* initialize from shared data */
@@ -582,7 +582,7 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 			form attribute.
 			}*/
 
-			OCIEnvNlsCreate_log_stat(imp_dbh, &imp_dbh->envhp, init_mode, 0, NULL, NULL, NULL, 0, 0,
+			OCIEnvNlsCreate_log_stat(imp_dbh, &imp_dbh->envhp, init_mode, 0, NULL, NULL, NULL, 0, NULL,
 				charsetid, ncharsetid, status );
 
 			if (status != OCI_SUCCESS) {
@@ -653,7 +653,7 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 	}
 
 	OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->errhp, OCI_HTYPE_ERROR,  status);
-	OCIAttrGet_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, &charsetid, (ub4)0 ,
+	OCIAttrGet_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, &charsetid, NULL,
 			OCI_ATTR_ENV_CHARSET_ID, imp_dbh->errhp, status);
 
 	if (status != OCI_SUCCESS) {
@@ -661,7 +661,7 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 		return 0;
 	}
 
-	OCIAttrGet_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, &ncharsetid, (ub4)0 ,
+	OCIAttrGet_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, &ncharsetid, NULL,
 			OCI_ATTR_ENV_NCHARSET_ID, imp_dbh->errhp, status);
 
 	if (status != OCI_SUCCESS) {
@@ -730,14 +730,14 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
                     (OraText **) &imp_dbh->pool_name,
                     (ub4 *) &imp_dbh->pool_namel,
                     (OraText *) dbname,
-                    strlen(dbname),
+                    (ub4)strlen(dbname),
                     imp_dbh->pool_min,
                     imp_dbh->pool_max,
                     imp_dbh->pool_incr,
                     (OraText *) uid,
-                    strlen(uid),
+                    (ub4)strlen(uid),
                     (OraText *) pwd,
-                    strlen(pwd),
+                    (ub4)strlen(pwd),
                     status);
 
 				if (status != OCI_SUCCESS) {
@@ -1878,7 +1878,7 @@ dbd_rebind_ph_varchar2_table(SV *sth, imp_sth_t *imp_sth, phs_t *phs)
 		phs->maxlen,
 		(ub2)SQLT_STR, phs->array_indicators,
 		phs->array_lengths,	/* ub2 *alen_ptr not needed with OCIBindDynamic */
-		(ub2)0,
+		NULL,
 		(ub4)phs->ora_maxarray_numentries, /* max elements that can fit in allocated array	*/
 		(ub4 *)&(phs->array_numstruct),	/* (ptr to) current number of elements in array	*/
 		OCI_DEFAULT,				/* OCI_DATA_AT_EXEC (bind with callbacks) or OCI_DEFAULT  */
@@ -1910,7 +1910,7 @@ dbd_rebind_ph_varchar2_table(SV *sth, imp_sth_t *imp_sth, phs_t *phs)
 	}
 
 	if (!phs->csid_orig) {	/* get the default csid Oracle would use */
-		OCIAttrGet_log_stat(imp_sth, phs->bndhp, OCI_HTYPE_BIND, &phs->csid_orig, (ub4)0 ,
+		OCIAttrGet_log_stat(imp_sth, phs->bndhp, OCI_HTYPE_BIND, &phs->csid_orig, NULL,
 			OCI_ATTR_CHARSET_ID, imp_sth->errhp, status);
 	}
 
@@ -2314,7 +2314,7 @@ int dbd_rebind_ph_number_table(SV *sth, imp_sth_t *imp_sth, phs_t *phs) {
                            phs->maxlen,
                            (ub2)phs->ora_internal_type, phs->array_indicators,
                            phs->array_lengths,
-                           (ub2)0,
+                           NULL,
                            (ub4)phs->ora_maxarray_numentries, /* max elements that can fit in allocated array	*/
                            (ub4 *)&(phs->array_numstruct),	/* (ptr to) current number of elements in array	*/
                            OCI_DEFAULT,				/* OCI_DATA_AT_EXEC (bind with callbacks) or OCI_DEFAULT  */
@@ -3048,7 +3048,7 @@ dbd_rebind_ph(SV *sth, imp_sth_t *imp_sth, phs_t *phs)
 	}
 
 	if (!phs->csid_orig) {	/* get the default csid Oracle would use */
-		OCIAttrGet_log_stat(imp_sth, phs->bndhp, OCI_HTYPE_BIND, &phs->csid_orig, (ub4)0 ,
+		OCIAttrGet_log_stat(imp_sth, phs->bndhp, OCI_HTYPE_BIND, &phs->csid_orig, NULL,
 		OCI_ATTR_CHARSET_ID, imp_sth->errhp, status);
 	}
 
@@ -3651,7 +3651,7 @@ do_bind_array_exec(sth, imp_sth, phs,utf8,parma_index,tuples_utf8_av,tuples_stat
 	}
 
 	if (!phs->csid_orig) {	  /* get the default csid Oracle would use */
-		OCIAttrGet_log_stat(imp_sth, phs->bndhp, OCI_HTYPE_BIND, &phs->csid_orig, (ub4)0 ,
+		OCIAttrGet_log_stat(imp_sth, phs->bndhp, OCI_HTYPE_BIND, &phs->csid_orig, NULL,
 			OCI_ATTR_CHARSET_ID, imp_sth->errhp, status);
 	}
 
@@ -4037,7 +4037,7 @@ dbd_st_blob_read(SV *sth, imp_sth_t *imp_sth, int field, long offset, long len, 
 		ora_free_templob(sth, imp_sth, (OCILobLocator*)fbh->desc_h);
 	return 0;
 	}
-	ftype = ftype;	/* no unused */
+	(void)ftype;	/* no unused */
 
 	if (DBIc_DBISTATE(imp_sth)->debug >= 3 || dbd_verbose >= 3 )
 	PerlIO_printf(
@@ -4308,7 +4308,7 @@ dbd_st_STORE_attrib(SV *sth, imp_sth_t *imp_sth, SV *keysv, SV *valuesv)
 
 	if (cachesv) /* cache value for later DBI 'quick' fetch? */
 		(void)hv_store((HV*)SvRV(sth), key, kl, cachesv, 0);
-		return TRUE;
+	return TRUE;
 }
 
 
@@ -4343,7 +4343,6 @@ dbd_st_FETCH_attrib(SV *sth, imp_sth_t *imp_sth, SV *keysv)
 	if (kl==4 && strEQ(key, "NAME")) {
 		AV *av = newAV();
         SV *x;
-        D_imp_dbh_from_sth;
 
 		retsv = newRV(sv_2mortal((SV*)av));
 		while(--i >= 0) {

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -219,6 +219,31 @@ dbd_dr_destroy(SV *drh, imp_drh_t *imp_drh)
 		/* Free cached environment handle. */
 		OCIHandleFree_log_stat(imp_drh, imp_drh->envhp, OCI_HTYPE_ENV, status);
 	}
+
+#ifdef ORA_OCI_112
+	/* Free session pool resources. */
+	if (imp_drh->pool_hv) {
+		HE *pool_he;
+		hv_iterinit(imp_drh->pool_hv);
+		while ((pool_he = hv_iternext(imp_drh->pool_hv))) {
+			session_pool_t *pool = (session_pool_t*)SvPVX(HeVAL(pool_he));
+			/* Only destroy the session pool if there are no active sessions left.
+			   If there are active sessions left, this is because "InactiveDestroy"
+			   is set on one or more db handles. */
+			if (!pool->active_sessions) {
+				OCISessionPoolDestroy_log_stat(imp_drh, pool->poolhp, pool->errhp, status);
+			}
+			OCIHandleFree_log_stat(imp_drh, pool->poolhp, OCI_HTYPE_SPOOL, status);
+			OCIHandleFree_log_stat(imp_drh, pool->errhp, OCI_HTYPE_ERROR, status);
+			OCIHandleFree_log_stat(imp_drh, pool->envhp, OCI_HTYPE_ENV, status);
+		}
+		hv_undef(imp_drh->pool_hv);
+	}
+
+	if (imp_drh->charset_hv) {
+		hv_undef(imp_drh->charset_hv);
+	}
+#endif
 }
 
 
@@ -382,6 +407,23 @@ fb_ary_free(fb_ary_t *fb_ary)
 
 }
 
+#ifdef ORA_OCI_112
+/* Helper functions to fetch cached session pool. */
+static SV *
+pool_key(imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, int csid, int ncsid)
+{
+	return newSVpvf("%s/%s@%s class=%.*s,csid=%d,ncsid=%d", uid, pwd, dbname, imp_dbh->pool_classl, imp_dbh->pool_class, csid, ncsid);
+}
+
+static session_pool_t *
+pool_fetch(imp_drh_t *imp_drh, SV *key)
+{
+	dTHX;
+	HE *pool_he = hv_fetch_ent(imp_drh->pool_hv, key, 0, 0);
+	return pool_he ? (session_pool_t *)SvPVX(HeVAL(pool_he)) : NULL;
+}
+#endif
+
 
 /* ================================================================== */
 
@@ -422,6 +464,8 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 #endif
 
 #ifdef ORA_OCI_112
+	session_pool_t *pool = NULL;
+
 	/*check to see if the user is connecting with DRCP */
 	if (DBD_ATTRIB_TRUE(attr,"ora_drcp",8,svp))
 		imp_dbh->using_drcp = 1;
@@ -441,6 +485,8 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 		DBD_ATTRIB_GET_IV( attr, "ora_drcp_max",  12, svp, imp_dbh->pool_max);
 	if (DBD_ATTRIB_TRUE(attr,"ora_drcp_incr",13,svp))
 		DBD_ATTRIB_GET_IV( attr, "ora_drcp_incr",  13, svp, imp_dbh->pool_incr);
+	if (DBD_ATTRIB_TRUE(attr,"ora_drcp_rlb",12,svp))
+		DBD_ATTRIB_GET_IV( attr, "ora_drcp_rlb",  12, svp, imp_dbh->pool_rlb);
 
 	imp_dbh->driver_name = "DBD::Oracle : " VERSION;
 #endif
@@ -534,18 +580,79 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 
 	imp_dbh->get_oci_handle = oci_db_handle;
 
-	if ((svp=DBD_ATTRIB_GET_SVP(attr, "ora_envhp", 9)) && SvOK(*svp)) {
-		if (!SvTRUE(*svp)) {
-			imp_dbh->envhp = NULL; /* force new environment */
+#ifdef ORA_OCI_112
+	if (!imp_dbh->using_drcp) {
+#endif
+		if ((svp=DBD_ATTRIB_GET_SVP(attr, "ora_envhp", 9)) && SvOK(*svp)) {
+			if (!SvTRUE(*svp)) {
+				imp_dbh->envhp = NULL; /* force new environment */
+			}
+		}
+		/* RT46739 */
+		if (imp_dbh->envhp) {
+			OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->errhp, OCI_HTYPE_ERROR, status);
+			if (status != OCI_SUCCESS) {
+				imp_dbh->envhp = NULL;
+			}
+		}
+#ifdef ORA_OCI_112
+	}
+	else if (!shared_dbh) {
+		/* Try to find session pool in cache. */
+		imp_dbh->envhp = NULL;
+
+		if (!imp_drh->charset_hv) {
+			imp_drh->charset_hv = newHV();
+		}
+		if (!imp_drh->pool_hv) {
+			imp_drh->pool_hv = newHV();
+		}
+
+		/* Get charset and ncharset IDs. */
+		if ((svp = DBD_ATTRIB_GET_SVP(attr, "ora_charset", 11))) {
+			/* Charset name from parameter; try looking up previously used ID. */
+			HE *charset_he = hv_fetch_ent(imp_drh->charset_hv, *svp, 0, 0);
+			charsetid = charset_he ? SvIV(HeVAL(charset_he)) : 0;
+		}
+		else {
+			/* Get charset ID from the NLS environment. */
+			size_t rsize;
+			OCINlsEnvironmentVariableGet_log_stat(imp_dbh, &charsetid, 0, OCI_NLS_CHARSET_ID, 0, &rsize, status);
+			if (status != OCI_SUCCESS) {
+				oci_error(dbh, NULL, status,
+					"OCINlsEnvironmentVariableGet(OCI_NLS_CHARSET_ID) Check NLS settings etc.");
+				return 0;
+			}
+		}
+		if ((svp = DBD_ATTRIB_GET_SVP(attr, "ora_ncharset", 12))) {
+			/* Charset name from parameter; try looking up previously used ID. */
+			HE *charset_he = hv_fetch_ent(imp_drh->charset_hv, *svp, 0, 0);
+			ncharsetid = charset_he ? SvIV(HeVAL(charset_he)) : 0;
+		}
+		else {
+			/* Get charset ID from the NLS environment. */
+			size_t rsize;
+			OCINlsEnvironmentVariableGet_log_stat(imp_dbh, &ncharsetid, 0, OCI_NLS_NCHARSET_ID, 0, &rsize, status);
+			if (status != OCI_SUCCESS) {
+				oci_error(dbh, NULL, status,
+					"OCINlsEnvironmentVariableGet(OCI_NLS_NCHARSET_ID) Check NLS settings etc.");
+					return 0;
+			}
+		}
+
+		if (charsetid && ncharsetid) {
+			/* Look up session pool initialized with the same dbname, uid/pwd, connection class, and charsets. */
+			SV *key_sv = pool_key(imp_dbh, dbname, uid, pwd, charsetid, ncharsetid);
+
+			if ((pool = pool_fetch(imp_drh, key_sv))) {
+				imp_dbh->pool = pool;
+				imp_dbh->envhp = pool->envhp;
+			}
+
+			sv_free(key_sv);
 		}
 	}
-    /* RT46739 */
-    if (imp_dbh->envhp) {
-        OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->errhp, OCI_HTYPE_ERROR, status);
-        if (status != OCI_SUCCESS) {
-            imp_dbh->envhp = NULL;
-        }
-    }
+#endif
 
     if (!imp_dbh->envhp ) {
 		SV **init_mode_sv;
@@ -613,6 +720,13 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 				if (!new_charsetid) {
 					croak("ora_charset value (%s) is not valid", SvPV_nolen(*svp));
 				}
+
+#ifdef ORA_OCI_112
+				if (imp_dbh->using_drcp) {
+					/* Store lookup from charset name to charset ID. */
+					(void)hv_store_ent(imp_drh->charset_hv, *svp, newSViv(new_charsetid), 0);
+				}
+#endif
 			}
 
 			svp = DBD_ATTRIB_GET_SVP(attr, "ora_ncharset", 12); /*get the ncharset passed in by the user*/
@@ -626,6 +740,13 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 				if (!new_ncharsetid) {
 					croak("ora_ncharset value (%s) is not valid", SvPV_nolen(*svp));
 				}
+
+#ifdef ORA_OCI_112
+				if (imp_dbh->using_drcp) {
+					/* Store lookup from charset name to charset ID. */
+					(void)hv_store_ent(imp_drh->charset_hv, *svp, newSViv(new_ncharsetid), 0);
+				}
+#endif
 			}
 
 			if (new_charsetid || new_ncharsetid) { /* reset the ENV with the new charset  from above*/
@@ -641,8 +762,11 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 				}
 			}
 
-			if (!imp_drh->envhp)	/* cache first envhp info drh as future default */
-				imp_drh->envhp = imp_dbh->envhp;
+#ifdef ORA_OCI_112
+			if (!imp_dbh->using_drcp)
+#endif
+				if (!imp_drh->envhp)	/* cache first envhp info drh as future default */
+					imp_drh->envhp = imp_dbh->envhp;
 
 			/* update the hard-coded csid constants for unicode charsets */
 			utf8_csid	   = OCINlsCharSetNameToId(imp_dbh->envhp, (void*)"UTF8");
@@ -650,6 +774,21 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 			al16utf16_csid = OCINlsCharSetNameToId(imp_dbh->envhp, (void*)"AL16UTF16");
 		}
 
+#ifdef ORA_OCI_112
+		if (imp_dbh->using_drcp) {
+			/* Try looking up session pool again, in case ora_charsetid/ora_ncharsetid were used to specify previously used charset IDs from the NLS environment. */
+			SV *key_sv = pool_key(imp_dbh, dbname, uid, pwd, charsetid, ncharsetid);
+
+			if ((pool = pool_fetch(imp_drh, key_sv))) {
+				imp_dbh->pool = pool;
+				/* Free the current environment handle and replace it with the session pool's environment handle. */
+				OCIHandleFree_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, status);
+				imp_dbh->envhp = pool->envhp;
+			}
+
+			sv_free(key_sv);
+		}
+#endif
 	}
 
 	if (!imp_dbh->errhp) {
@@ -696,173 +835,190 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 
 	if (!shared_dbh) {
 
-		OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
+#ifdef ORA_OCI_112
 
-		if (status != OCI_SUCCESS) {
-			oci_error(dbh, imp_dbh->errhp, status, "OCIServerAttach");
-			OCIHandleFree_log_stat(imp_dbh, imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
-			OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR,  status);
-			return 0;
+		if (imp_dbh->using_drcp) { /* connect using a DRCP */
+			OCIAuthInfo *authp;
+			ub4   purity = OCI_ATTR_PURITY_SELF;
+			/* pool Default values */
+			if (!imp_dbh->pool_min )
+				imp_dbh->pool_min = 0;
+			if (!imp_dbh->pool_max )
+				imp_dbh->pool_max = 40;
+			if (!imp_dbh->pool_incr)
+				imp_dbh->pool_incr = 1;
+			if (!imp_dbh->pool_rlb)
+				imp_dbh->pool_rlb = 0;
+
+			if (!pool) {
+				/* Create and cache new session pool struct. */
+				SV *key_sv = pool_key(imp_dbh, dbname, uid, pwd, charsetid, ncharsetid);
+
+				session_pool_t pool_data = { };
+				SV *pool_sv = newSVpvn((char*)&pool_data, sizeof(pool_data));
+				HE *pool_he = hv_store_ent(imp_drh->pool_hv, key_sv, pool_sv, 0);
+				imp_dbh->pool = pool = (session_pool_t*)SvPVX(HeVAL(pool_he));
+				pool->envhp = imp_dbh->envhp;
+
+				sv_free(key_sv);
+
+				OCIHandleAlloc_ok(imp_dbh, pool->envhp, &pool->poolhp, OCI_HTYPE_SPOOL, status);
+				OCIHandleAlloc_ok(imp_dbh, pool->envhp, &authp, OCI_HTYPE_AUTHINFO, status);
+				/* Create an unshared error handle for use in pool creation and destruction. */
+				OCIHandleAlloc_ok(imp_dbh, pool->envhp, &pool->errhp, OCI_HTYPE_ERROR,  status);
+
+				OCIAttrSet_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO,
+					imp_dbh->driver_name, (ub4)strlen(imp_dbh->driver_name),
+					OCI_ATTR_DRIVER_NAME, pool->errhp, status);
+
+				OCIAttrSet_log_stat(imp_dbh, pool->poolhp, OCI_HTYPE_SPOOL,
+					authp, (ub4)0, OCI_ATTR_SPOOL_AUTH, pool->errhp, status);
+
+				ora_parse_uid(imp_dbh, &uid, &pwd);
+
+				OCISessionPoolCreate_log_stat(
+					imp_dbh,
+					pool->envhp,
+					pool->errhp,
+					pool->poolhp,
+					&pool->pool_name,
+					&pool->pool_namel,
+					(OraText *) dbname,
+					(ub4)strlen(dbname),
+					imp_dbh->pool_min,
+					imp_dbh->pool_max,
+					imp_dbh->pool_incr,
+					(OraText *) uid,
+					(ub4)strlen(uid),
+					(OraText *) pwd,
+					(ub4)strlen(pwd),
+					OCI_SPC_HOMOGENEOUS | (imp_dbh->pool_rlb ? 0 : OCI_SPC_NO_RLB),
+					status);
+
+				if (status != OCI_SUCCESS) {
+					oci_error(dbh, pool->errhp, status, "OCISessionPoolCreate");
+					OCIHandleFree_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO, status);
+					OCIHandleFree_log_stat(imp_dbh, pool->poolhp, OCI_HTYPE_SPOOL,status);
+					OCIHandleFree_log_stat(imp_dbh, pool->errhp, OCI_HTYPE_ERROR,  status);
+					/* Free the global error handle as well. */
+					OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR, status);
+					OCIHandleFree_log_stat(imp_dbh, pool->envhp, OCI_HTYPE_ENV, status);
+
+					(void)hv_delete_ent(imp_drh->pool_hv, HeSVKEY(pool_he), 0, 0);
+					return 0;
+				}
+
+				OCIHandleFree_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO, status);
+			}
+
+			OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &authp, OCI_HTYPE_AUTHINFO, status);
+
+			OCIAttrSet_log_stat(imp_dbh, authp, (ub4) OCI_HTYPE_AUTHINFO,
+						&purity, (ub4) 0,(ub4) OCI_ATTR_PURITY, imp_dbh->errhp, status);
+
+			if (imp_dbh->pool_class) /*pool_class may or may not be used */
+				OCIAttrSet_log_stat(imp_dbh, authp, (ub4) OCI_HTYPE_AUTHINFO,
+							(OraText *) imp_dbh->pool_class, (ub4) imp_dbh->pool_classl,
+							(ub4) OCI_ATTR_CONNECTION_CLASS, imp_dbh->errhp, status);
+
+			/* Use session tagging to get a server session initalized with correct charsets. */
+			sprintf((char*)imp_dbh->session_tag, "csid=%d,ncsid=%d", charsetid, ncharsetid);
+
+			OCISessionGet_log_stat(imp_dbh, imp_dbh->envhp, imp_dbh->errhp, &imp_dbh->svchp, authp,
+						pool->pool_name, (ub4)strlen((char *)pool->pool_name),
+						imp_dbh->session_tag, (ub4)strlen((char *)imp_dbh->session_tag), &imp_dbh->session_tag_found, status);
+			if (status != OCI_SUCCESS) {
+				oci_error(dbh, imp_dbh->errhp, status, "OCISessionGet");
+				OCIHandleFree_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO, status);
+				return 0;
+			}
+
+			/* Update number of active sessions in the pool. */
+			++imp_dbh->pool->active_sessions;
+
+			OCIHandleFree_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO, status);
+
+			/* Get server and session handles from service context handle, allocated by OCISessionGet. */
+			OCIAttrGet_log_stat(imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, &imp_dbh->srvhp, NULL,
+				OCI_ATTR_SERVER, imp_dbh->errhp, status);
+			OCIAttrGet_log_stat(imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, &imp_dbh->seshp, NULL,
+				OCI_ATTR_SESSION, imp_dbh->errhp, status);
+
+			if (DBIc_DBISTATE(imp_dbh)->debug >= 4 || dbd_verbose >= 4 ) {
+				PerlIO_printf(
+				DBIc_LOGPIO(imp_dbh),
+					"Using DRCP with session settings min=%d, max=%d, and increment=%d\n",
+					imp_dbh->pool_min,
+					imp_dbh->pool_max,
+					imp_dbh->pool_incr);
+				if (imp_dbh->pool_class)
+					PerlIO_printf(
+						DBIc_LOGPIO(imp_dbh),
+						"with connection class=%s\n",imp_dbh->pool_class);
+			}
+
 		}
+		else {
+#endif /* ORA_OCI_112 */
 
-		{
 			SV **sess_mode_type_sv;
 			ub4  sess_mode_type = OCI_DEFAULT;
 			ub4  cred_type;
 			DBD_ATTRIB_GET_IV(attr, "ora_session_mode",16, sess_mode_type_sv, sess_mode_type);
 
-#ifdef ORA_OCI_112
-
-			if (imp_dbh->using_drcp) { /* connect uisng a DRCP */
-				OCIAuthInfo *authp;
-				ub4   purity = OCI_ATTR_PURITY_SELF;
-				/* pool Default values */
-				if (!imp_dbh->pool_min )
-					imp_dbh->pool_min = 4;
-				if (!imp_dbh->pool_max )
-					imp_dbh->pool_max = 40;
-				if (!imp_dbh->pool_incr)
-					imp_dbh->pool_incr = 2;
-
-				OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->poolhp, OCI_HTYPE_SPOOL, status);
-				OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &authp, OCI_HTYPE_AUTHINFO, status);
-
-				OCIAttrSet_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO,
-					imp_dbh->driver_name, (ub4)strlen(imp_dbh->driver_name),
-					OCI_ATTR_DRIVER_NAME, imp_dbh->errhp, status);
-
-				OCIAttrSet_log_stat(imp_dbh, imp_dbh->poolhp, OCI_HTYPE_SPOOL,
-					authp, (ub4)0, OCI_ATTR_SPOOL_AUTH, imp_dbh->errhp, status);
-
-				OCISessionPoolCreate_log_stat(
-                    imp_dbh,
-                    imp_dbh->envhp,
-                    imp_dbh->errhp,
-                    imp_dbh->poolhp,
-                    (OraText **) &imp_dbh->pool_name,
-                    (ub4 *) &imp_dbh->pool_namel,
-                    (OraText *) dbname,
-                    (ub4)strlen(dbname),
-                    imp_dbh->pool_min,
-                    imp_dbh->pool_max,
-                    imp_dbh->pool_incr,
-                    (OraText *) uid,
-                    (ub4)strlen(uid),
-                    (OraText *) pwd,
-                    (ub4)strlen(pwd),
-                    status);
-
-				if (status != OCI_SUCCESS) {
-
-					oci_error(dbh, imp_dbh->errhp, status, "OCISessionPoolCreate");
-					OCIServerDetach_log_stat(imp_dbh, imp_dbh->srvhp, imp_dbh->errhp, OCI_DEFAULT, status);
-					OCIHandleFree_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO, status);
-					OCIHandleFree_log_stat(imp_dbh, imp_dbh->poolhp, OCI_HTYPE_SPOOL,status);
-					OCIHandleFree_log_stat(imp_dbh, imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
-					OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR,  status);
-					return 0;
+			OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
+			OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->svchp, OCI_HTYPE_SVCCTX, status);
+			OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->seshp, OCI_HTYPE_SESSION, status);
+			OCIServerAttach_log_stat(imp_dbh, dbname,OCI_DEFAULT, status);
+			if (status != OCI_SUCCESS) {
+				oci_error(dbh, imp_dbh->errhp, status, "OCIServerAttach");
+				OCIHandleFree_log_stat(imp_dbh, imp_dbh->seshp, OCI_HTYPE_SESSION,status);
+				OCIHandleFree_log_stat(imp_dbh, imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
+				OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR, status);
+				OCIHandleFree_log_stat(imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, status);
+				if (imp_dbh->envhp != imp_drh->envhp) {
+					OCIHandleFree_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, status);
 				}
-
-				OCIHandleFree_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO, status);
-
-				OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->authp, OCI_HTYPE_AUTHINFO, status);
-
-				OCIAttrSet_log_stat(imp_dbh, imp_dbh->authp, (ub4) OCI_HTYPE_AUTHINFO,
-							&purity, (ub4) 0,(ub4) OCI_ATTR_PURITY, imp_dbh->errhp, status);
-
-				if (imp_dbh->pool_class) /*pool_class may or may not be used */
-                    OCIAttrSet_log_stat(imp_dbh, imp_dbh->authp, (ub4) OCI_HTYPE_AUTHINFO,
-								(OraText *) imp_dbh->pool_class, (ub4) imp_dbh->pool_classl,
-								(ub4) OCI_ATTR_CONNECTION_CLASS, imp_dbh->errhp, status);
-
-				cred_type = ora_parse_uid(imp_dbh, &uid, &pwd);
-
-				OCISessionGet_log_stat(imp_dbh, imp_dbh->envhp, imp_dbh->errhp, &imp_dbh->svchp, imp_dbh->authp,
-								imp_dbh->pool_name, (ub4)strlen((char *)imp_dbh->pool_name), status);
-
-				if (status != OCI_SUCCESS) {
-
-					oci_error(dbh, imp_dbh->errhp, status, "OCISessionGet");
-					OCIServerDetach_log_stat(imp_dbh, imp_dbh->srvhp, imp_dbh->errhp, OCI_DEFAULT, status);
-					OCISessionPoolDestroy_log_stat(
-                        imp_dbh, imp_dbh->poolhp, imp_dbh->errhp,status);
-					OCIHandleFree_log_stat(imp_dbh, imp_dbh->poolhp, OCI_HTYPE_SPOOL,status);
-					OCIHandleFree_log_stat(imp_dbh, imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
-					OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR,  status);
-					return 0;
-				}
-
-				if (DBIc_DBISTATE(imp_dbh)->debug >= 4 || dbd_verbose >= 4 ) {
-					PerlIO_printf(
-                        DBIc_LOGPIO(imp_dbh),
-                        "Using DRCP with session settings min=%d, max=%d, and increment=%d\n",
-                        imp_dbh->pool_min,
-						imp_dbh->pool_max,
-						imp_dbh->pool_incr);
-					if (imp_dbh->pool_class)
-						PerlIO_printf(
-                            DBIc_LOGPIO(imp_dbh),
-                            "with connection class=%s\n",imp_dbh->pool_class);
-					}
-
-				}
-				else {
-#endif /* ORA_OCI_112 */
-
-					OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->svchp, OCI_HTYPE_SVCCTX, status);
-					OCIServerAttach_log_stat(imp_dbh, dbname,OCI_DEFAULT, status);
-                    if (status != OCI_SUCCESS) {
-                        oci_error(dbh, imp_dbh->errhp, status, "OCIServerAttach");
-                        OCIHandleFree_log_stat(imp_dbh, imp_dbh->seshp, OCI_HTYPE_SESSION,status);
-                        OCIHandleFree_log_stat(imp_dbh, imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
-                        OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR, status);
-                        OCIHandleFree_log_stat(imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, status);
-                        if (imp_dbh->envhp != imp_drh->envhp) {
-                            OCIHandleFree_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, status);
-                        }
-                        return 0;
-                    }
-
-
-					OCIAttrSet_log_stat(imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, imp_dbh->srvhp,
-									(ub4) 0, OCI_ATTR_SERVER, imp_dbh->errhp, status);
-
-					OCIHandleAlloc_ok(imp_dbh, imp_dbh->envhp, &imp_dbh->seshp, OCI_HTYPE_SESSION, status);
-
-					cred_type = ora_parse_uid(imp_dbh, &uid, &pwd);
-
-#ifdef ORA_OCI_112
-					OCIAttrSet_log_stat(imp_dbh, imp_dbh->seshp, (ub4)OCI_HTYPE_SESSION,
-						imp_dbh->driver_name, (ub4)strlen(imp_dbh->driver_name),
-						(ub4)OCI_ATTR_DRIVER_NAME, imp_dbh->errhp, status);
-#endif
-
-					OCISessionBegin_log_stat(imp_dbh, imp_dbh->svchp, imp_dbh->errhp, imp_dbh->seshp,cred_type, sess_mode_type, status);
-
-					if (status == OCI_SUCCESS_WITH_INFO) {
-						/* eg ORA-28011: the account will expire soon; change your password now */
-						oci_error(dbh, imp_dbh->errhp, status, "OCISessionBegin");
-						status = OCI_SUCCESS;
-					}
-					if (status != OCI_SUCCESS) {
-						oci_error(dbh, imp_dbh->errhp, status, "OCISessionBegin");
-						OCIServerDetach_log_stat(imp_dbh, imp_dbh->srvhp, imp_dbh->errhp, OCI_DEFAULT, status);
-						OCIHandleFree_log_stat(imp_dbh, imp_dbh->seshp, OCI_HTYPE_SESSION,status);
-						OCIHandleFree_log_stat(imp_dbh, imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
-						OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR,  status);
-						OCIHandleFree_log_stat(imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, status);
-						if (imp_dbh->envhp != imp_drh->envhp) {
-							OCIHandleFree_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, status);
-						}
-						return 0;
-					}
-
-					OCIAttrSet_log_stat(imp_dbh, imp_dbh->svchp, (ub4) OCI_HTYPE_SVCCTX,
-								imp_dbh->seshp, (ub4) 0,(ub4) OCI_ATTR_SESSION, imp_dbh->errhp, status);
-#ifdef ORA_OCI_112
-				}
-#endif
+				return 0;
 			}
+
+
+			OCIAttrSet_log_stat(imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, imp_dbh->srvhp,
+							(ub4) 0, OCI_ATTR_SERVER, imp_dbh->errhp, status);
+
+			cred_type = ora_parse_uid(imp_dbh, &uid, &pwd);
+
+#ifdef ORA_OCI_112
+			OCIAttrSet_log_stat(imp_dbh, imp_dbh->seshp, (ub4)OCI_HTYPE_SESSION,
+				imp_dbh->driver_name, (ub4)strlen(imp_dbh->driver_name),
+				(ub4)OCI_ATTR_DRIVER_NAME, imp_dbh->errhp, status);
+#endif
+
+			OCISessionBegin_log_stat(imp_dbh, imp_dbh->svchp, imp_dbh->errhp, imp_dbh->seshp,cred_type, sess_mode_type, status);
+
+			if (status == OCI_SUCCESS_WITH_INFO) {
+				/* eg ORA-28011: the account will expire soon; change your password now */
+				oci_error(dbh, imp_dbh->errhp, status, "OCISessionBegin");
+				status = OCI_SUCCESS;
+			}
+			if (status != OCI_SUCCESS) {
+				oci_error(dbh, imp_dbh->errhp, status, "OCISessionBegin");
+				OCIServerDetach_log_stat(imp_dbh, imp_dbh->srvhp, imp_dbh->errhp, OCI_DEFAULT, status);
+				OCIHandleFree_log_stat(imp_dbh, imp_dbh->seshp, OCI_HTYPE_SESSION,status);
+				OCIHandleFree_log_stat(imp_dbh, imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
+				OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR,  status);
+				OCIHandleFree_log_stat(imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, status);
+				if (imp_dbh->envhp != imp_drh->envhp) {
+					OCIHandleFree_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, status);
+				}
+				return 0;
+			}
+
+			OCIAttrSet_log_stat(imp_dbh, imp_dbh->svchp, (ub4) OCI_HTYPE_SVCCTX,
+						imp_dbh->seshp, (ub4) 0,(ub4) OCI_ATTR_SESSION, imp_dbh->errhp, status);
+#ifdef ORA_OCI_112
+		}
+#endif
 
 	}
 
@@ -1014,23 +1170,33 @@ dbd_db_disconnect(SV *dbh, imp_dbh_t *imp_dbh)
 	/* See DBI Driver.xst file for the DBI approach.	*/
 
 	if (refcnt == 1 ) {
-		sword s_se, s_sd;
 #ifdef ORA_OCI_112
 		if (imp_dbh->using_drcp) {
-			OCISessionRelease_log_stat(imp_dbh, imp_dbh->svchp, imp_dbh->errhp,s_se);
+			sword status;
+			/* Release session, tagged for future retrieval. */
+			OCISessionRelease_log_stat(imp_dbh, imp_dbh->svchp, imp_dbh->errhp,
+				imp_dbh->session_tag, (ub4)strlen((char *)imp_dbh->session_tag), imp_dbh->session_tag_found ? OCI_DEFAULT : OCI_SESSRLS_RETAG, status);
+			if (status != OCI_SUCCESS) {
+				oci_error(dbh, imp_dbh->errhp, status, "OCISessionRelease");
+				return 0;
+			}
+
+			/* Update number of active sessions in the pool */
+			--imp_dbh->pool->active_sessions;
 		}
 		else {
 #endif
+			sword s_se, s_sd;
 			OCISessionEnd_log_stat(imp_dbh, imp_dbh->svchp, imp_dbh->errhp, imp_dbh->seshp,
 			  OCI_DEFAULT, s_se);
+			if (s_se) oci_error(dbh, imp_dbh->errhp, s_se, "OCISessionEnd");
+			OCIServerDetach_log_stat(imp_dbh, imp_dbh->srvhp, imp_dbh->errhp, OCI_DEFAULT, s_sd);
+			if (s_sd) oci_error(dbh, imp_dbh->errhp, s_sd, "OCIServerDetach");
+			if (s_se != OCI_SUCCESS || s_sd != OCI_SUCCESS)
+				return 0;
 #ifdef ORA_OCI_112
 		}
 #endif
-		if (s_se) oci_error(dbh, imp_dbh->errhp, s_se, "OCISessionEnd");
-		OCIServerDetach_log_stat(imp_dbh, imp_dbh->srvhp, imp_dbh->errhp, OCI_DEFAULT, s_sd);
-		if (s_sd) oci_error(dbh, imp_dbh->errhp, s_sd, "OCIServerDetach");
-		if (s_se || s_sd)
-			return 0;
 	}
 	/* We don't free imp_dbh since a reference still exists	*/
 	/* The DESTROY method is the only one to 'free' memory.	*/
@@ -1055,8 +1221,6 @@ dbd_db_destroy(SV *dbh, imp_dbh_t *imp_dbh)
 #endif
 
 	if (refcnt == 1) {
-		sword status;
-
 		if (DBIc_ACTIVE(imp_dbh))
 			dbd_db_disconnect(dbh, imp_dbh);
 		if (is_extproc)
@@ -1078,22 +1242,20 @@ dbd_db_destroy(SV *dbh, imp_dbh_t *imp_dbh)
 
 #ifdef ORA_OCI_112
 		if (imp_dbh->using_drcp) {
-			OCIHandleFree_log_stat(imp_dbh, imp_dbh->authp, OCI_HTYPE_SESSION,status);
-			OCISessionPoolDestroy_log_stat(imp_dbh, imp_dbh->poolhp, imp_dbh->errhp,status);
-			OCIHandleFree_log_stat(imp_dbh, imp_dbh->poolhp, OCI_HTYPE_SPOOL,status);
+			OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR,  status);
 		}
 		else {
 #endif
 			OCIHandleFree_log_stat(imp_dbh, imp_dbh->seshp, OCI_HTYPE_SESSION,status);
 			OCIHandleFree_log_stat(imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, status);
+			OCIHandleFree_log_stat(imp_dbh, imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
+			OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR,  status);
+			if (imp_dbh->envhp != imp_drh->envhp) {
+				OCIHandleFree_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, status);
+			}
 #ifdef ORA_OCI_112
 		}
 #endif
-		OCIHandleFree_log_stat(imp_dbh, imp_dbh->srvhp, OCI_HTYPE_SERVER, status);
-		OCIHandleFree_log_stat(imp_dbh, imp_dbh->errhp, OCI_HTYPE_ERROR,  status);
-		if (imp_dbh->envhp != imp_drh->envhp) {
-			OCIHandleFree_log_stat(imp_dbh, imp_dbh->envhp, OCI_HTYPE_ENV, status);
-		}
 	}
 	else {
 		/* A new error handle is allocated on each new connect, so it is also freed when
@@ -1162,6 +1324,9 @@ dbd_db_STORE_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv, SV *valuesv)
 	}
 	else if (kl==13 && strEQ(key, "ora_drcp_incr") ) {
 		imp_dbh->pool_incr = SvIV (valuesv);
+	}
+	else if (kl==12 && strEQ(key, "ora_drcp_rlb") ) {
+		imp_dbh->pool_rlb = SvIV (valuesv);
 	}
 #endif
 	else if (kl==16 && strEQ(key, "ora_taf_function") ) {
@@ -1283,6 +1448,9 @@ dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
 	}
 	else if (kl==13 && strEQ(key, "ora_drcp_incr") ) {
 		retsv = newSViv(imp_dbh->pool_incr);
+	}
+	else if (kl==12 && strEQ(key, "ora_drcp_rlb") ) {
+		retsv = newSViv(imp_dbh->pool_rlb);
 	}
 #endif
 	else if (kl==16 && strEQ(key, "ora_taf_function") ) {

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -657,6 +657,10 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
     if (!imp_dbh->envhp ) {
 		SV **init_mode_sv;
 		ub4 init_mode = OCI_OBJECT;/* needed for LOBs (8.0.4)	*/
+
+		if (DBD_ATTRIB_TRUE(attr, "ora_events", 10, svp))
+			init_mode |= OCI_EVENTS; /* Needed for Oracle Fast Application Notification (FAN). */
+
 		DBD_ATTRIB_GET_IV(attr, "ora_init_mode",13, init_mode_sv, init_mode);
 
 #if defined(USE_ITHREADS) || defined(MULTIPLICITY) || defined(USE_5005THREADS)

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -21,6 +21,7 @@ typedef struct imp_fbh_st imp_fbh_t;
 struct imp_drh_st {
 	dbih_drc_t com;		/* MUST be first element in structure	*/
 	OCIEnv *envhp;
+	bool leak_state;
 	SV *ora_long;
 	SV *ora_trunc;
 	SV *ora_cache;
@@ -394,6 +395,7 @@ sb4 reg_taf_callback _((SV *dbh, imp_dbh_t *imp_dbh));
 /* These defines avoid name clashes for multiple statically linked DBD's	*/
 
 #define dbd_init			ora_init
+#define dbd_dr_destroy		ora_dr_destroy
 #define dbd_db_login		ora_db_login
 #define dbd_db_login6		ora_db_login6
 #define dbd_db_do			ora_db_do
@@ -402,6 +404,7 @@ sb4 reg_taf_callback _((SV *dbh, imp_dbh_t *imp_dbh));
 #define dbd_db_cancel		ora_db_cancel
 #define dbd_db_disconnect	ora_db_disconnect
 #define dbd_db_destroy		ora_db_destroy
+#define dbd_take_imp_data	ora_take_imp_data
 #define dbd_db_STORE_attrib	ora_db_STORE_attrib
 #define dbd_db_FETCH_attrib	ora_db_FETCH_attrib
 #define dbd_st_prepare		ora_st_prepare

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -22,11 +22,27 @@ struct imp_drh_st {
 	dbih_drc_t com;		/* MUST be first element in structure	*/
 	OCIEnv *envhp;
 	bool leak_state;
+#ifdef ORA_OCI_112
+	HV *charset_hv;
+	HV *pool_hv;
+#endif
 	SV *ora_long;
 	SV *ora_trunc;
 	SV *ora_cache;
 	SV *ora_cache_o;		/* for ora_open() cache override */
 };
+
+#ifdef ORA_OCI_112
+typedef struct session_pool_st session_pool_t;
+struct session_pool_st {
+	OCIEnv		*envhp;
+	OCIError 	*errhp;
+	OCISPool	*poolhp;
+	OraText		*pool_name;
+	ub4		pool_namel;
+	int		active_sessions;
+};
+#endif
 
 /* Define dbh implementor data structure */
 struct imp_dbh_st {
@@ -45,16 +61,16 @@ struct imp_dbh_st {
 	OCISvcCtx 	*svchp;
 	OCISession	*seshp;
 #ifdef ORA_OCI_112
-	OCIAuthInfo *authp;
-	OCISPool    *poolhp;
-	text        *pool_name;
-	ub4			pool_namel;
+	session_pool_t	*pool;
+	OraText		session_tag[50];
+	boolean		session_tag_found;
 	bool		using_drcp;
 	text		*pool_class;
 	ub4			pool_classl;
 	ub4			pool_min;
 	ub4			pool_max;
 	ub4			pool_incr;
+	ub4			pool_rlb;
 	char		*driver_name;/*driver name user defined*/
 #endif
     SV          *taf_function; /*User supplied TAF functiomn*/

--- a/dist.ini
+++ b/dist.ini
@@ -30,7 +30,7 @@ authority=cpan:PYTHIAN
 -remove=CoderwallEndorse
 
 [Prereqs / ConfigureRequires]
-DBI = 1.51
+DBI = 1.623
 
 [HelpWanted]
 positions = coder documentation tester

--- a/lib/DBD/Oracle.pm
+++ b/lib/DBD/Oracle.pm
@@ -45,7 +45,7 @@ package DBD::Oracle;
 
     my $Revision = substr(q$Revision: 1.103 $, 10);
 
-    require_version DBI 1.51;
+    require_version DBI 1.623;
 
     DBD::Oracle->bootstrap($DBD::Oracle::VERSION);
 

--- a/lib/DBD/Oracle.pm
+++ b/lib/DBD/Oracle.pm
@@ -294,6 +294,9 @@ package DBD::Oracle;
 	if (exists $ENV{ORA_DRCP_INCR}) {
 	   $attr->{ora_drcp_incr} = $ENV{ORA_DRCP_INCR}
 	}
+	if (exists $ENV{ORA_DRCP_RLB}) {
+	   $attr->{ora_drcp_rlb} = $ENV{ORA_DRCP_RLB}
+	}
 
 	{
 	   local @SIG{ @{ $attr->{ora_connect_with_default_signals} } }
@@ -396,6 +399,7 @@ package DBD::Oracle;
                  ora_drcp_min		=> undef,
                  ora_drcp_max		=> undef,
                  ora_drcp_incr		=> undef,
+                 ora_drcp_rlb		=> undef,
                  ora_oratab_orahome	=> undef,
                  ora_module_name	=> undef,
                  ora_driver_name	=> undef,
@@ -1564,16 +1568,24 @@ than 1024 characters.
 This value can be also be specified with the C<ORA_DRCP_CLASS>
 environment variable.
 
+Note that a connection class must be specified in order to enable
+inter-process sharing of server side sessions.
+
 =head4 ora_drcp_min
 
 This optional value specifies the minimum number of sessions that are
-initially opened.  New sessions are only opened after this value has
-been reached.
+initially allocated for the application process.  New sessions are only
+allocated after this value has been reached.
 
-The default value is 4 and  any value above 0 is valid.
+The default value is 0 and any value greater than or equal to 0 is valid.
 
-Generally, it should be set to the number of concurrent statements the
-application is planning or expecting to run.
+For multi-process applications, it is recommended to leave the value at 0.
+This ensures that each process is only occupying a server session while
+the process is doing database work.
+
+For multi-threaded applications, the value could be set to the number of
+concurrent statements the application is planning or expecting to run.
+Please note that DRCP has not been tested with multi-threading.
 
 This value can also be specified with the C<ORA_DRCP_MIN> environment
 variable.
@@ -1582,7 +1594,7 @@ variable.
 
 This optional value specifies the maximum number of sessions that can
 be open at one time.  Once reached no more sessions can be opened
-until one becomes free. The default value is 40 and any value above 1
+until one becomes free. The default value is 40 and any value above 0
 is valid.  You should not set this value lower than ora_drcp_min as
 that will just waste resources.
 
@@ -1593,11 +1605,20 @@ variable.
 
 This optional value specifies the next increment for sessions to be
 started if the current number of sessions are less than
-ora_drcp_max. The default value is 2 and any value above 0 is
+ora_drcp_max. The default value is 1 and any value above 0 is
 valid as long as the value of ora_drcp_min + ora_drcp_incr is not
 greater than ora_drcp_max.
 
 This value can also be specified with the C<ORA_DRCP_INCR> environment
+variable.
+
+=head4 ora_drcp_rlb
+
+This optional value controls whether run-time connection load balancing
+is used for Oracle RAC. The default value is 0, which disables the feature.
+Set the value to 1 to enable the feature.
+
+This value can also be specified with the C<ORA_DRCP_RLB> environment
 variable.
 
 =head4 ora_taf
@@ -1661,6 +1682,8 @@ a SID so that Oracle then uses the value of ORACLE_SID (not
 TWO_TASK) environment variable to connect to a local instance. Also
 the username and password should be empty, and the user executing the
 script needs to be part of the dba group or osdba group.
+
+Note that this does not work with DRCP.
 
 =head4 ora_oratab_orahome
 
@@ -1766,6 +1789,11 @@ The OCI environment holds information about the client side context,
 such as the local NLS environment. By altering C<%ENV> and setting
 ora_envhp to 0 you can create connections with different NLS
 settings. This is most useful for testing.
+
+Note that for DRCP, setting C<ora_envhp = 0> has no effect. Here,
+a new session pool is created, using the current NLS environment,
+for each new combination of dbname, uid/pwd, connection class,
+and charset/ncharset.
 
 =head4 ora_charset, ora_ncharset
 
@@ -1924,7 +1952,7 @@ variables.
 =head2 B<connect_cached>
 
 Implemented by DBI, no driver-specific impact.
-Please note that connect_cached as not been tested with DRCP.
+Please note that connect_cached has not been tested with DRCP.
 
 =head2 B<data_sources>
 
@@ -2096,7 +2124,7 @@ DBMS_OUTPUT.PUT, or DBMS_OUTPUT.NEW_LINE.
 =head2 B<reauthenticate ( $username, $password )>
 
 Starts a new session against the current database using the credentials
-supplied.
+supplied. Note that this does not work with DRCP.
 
 
 =head2 B<private_attribute_info>

--- a/lib/DBD/Oracle.pm
+++ b/lib/DBD/Oracle.pm
@@ -298,6 +298,10 @@ package DBD::Oracle;
 	   $attr->{ora_drcp_rlb} = $ENV{ORA_DRCP_RLB}
 	}
 
+	if (exists $ENV{ORA_EVENTS}) {
+	   $attr->{ora_events} = $ENV{ORA_EVENTS};
+	}
+
 	{
 	   local @SIG{ @{ $attr->{ora_connect_with_default_signals} } }
           if $attr->{ora_connect_with_default_signals};
@@ -387,6 +391,7 @@ package DBD::Oracle;
                  ora_svchp		=> undef,
                  ora_errhp		=> undef,
                  ora_init_mode		=> undef,
+                 ora_events		=> undef,
                  ora_charset		=> undef,
                  ora_ncharset		=> undef,
                  ora_session_mode	=> undef,
@@ -1773,6 +1778,12 @@ string.
   our $orashr : shared = '' ;
 
   $dbh = DBI->connect ($dsn, $user, $passwd, {ora_dbh_share => \$orashr}) ;
+
+=head4 ora_events
+
+Set this attribute to C<1> to enable Oracle Fast Application Notification
+(FAN) in a new OCI environment. Can also be set via the C<ORA_EVENTS>
+environment variable.
 
 =head4 ora_envhp
 

--- a/oci8.c
+++ b/oci8.c
@@ -4260,16 +4260,7 @@ ora_parse_uid(imp_dbh_t *imp_dbh, char **uidp, char **pwdp)
 		return OCI_CRED_EXT;
 	}
 #ifdef ORA_OCI_112
-    if (imp_dbh->using_drcp){
-		OCIAttrSet_log_stat(imp_dbh, imp_dbh->authp, OCI_HTYPE_SESSION,
-			*uidp, strlen(*uidp),
-			(ub4) OCI_ATTR_USERNAME, imp_dbh->errhp, status);
-
-		OCIAttrSet_log_stat(imp_dbh, imp_dbh->authp, OCI_HTYPE_SESSION,
-			(strlen(*pwdp)) ? *pwdp : NULL, strlen(*pwdp),
-			(ub4) OCI_ATTR_PASSWORD, imp_dbh->errhp, status);
-	}
-	else {
+	if (!imp_dbh->using_drcp) {
 #endif
 		OCIAttrSet_log_stat(imp_dbh, imp_dbh->seshp, OCI_HTYPE_SESSION,
 				*uidp, strlen(*uidp),
@@ -4290,6 +4281,11 @@ ora_db_reauthenticate(SV *dbh, imp_dbh_t *imp_dbh, char *uid, char *pwd)
 {
 	dTHX;
 	sword status;
+#ifdef ORA_OCI_112
+	if (imp_dbh->using_drcp) {
+		return 0;
+	}
+#endif
 	/* XXX should possibly create new session before ending the old so	*/
 	/* that if the new one can't be created, the old will still work.	*/
 	OCISessionEnd_log_stat(imp_dbh, imp_dbh->svchp, imp_dbh->errhp,

--- a/oci8.c
+++ b/oci8.c
@@ -288,7 +288,9 @@ oci_mode(ub4  mode)
 	dTHX;
 	SV *sv;
 	switch (mode) {
-		case 3:					return "THREADED | OBJECT";
+		case OCI_THREADED | OCI_OBJECT:	return "THREADED | OBJECT";
+		case OCI_OBJECT | OCI_EVENTS:	return "OBJECT | EVENTS";
+		case OCI_THREADED | OCI_OBJECT | OCI_EVENTS:	return "THREADED | OBJECT | EVENTS";
 		case OCI_DEFAULT:		return "DEFAULT";
 		/* the default value for parameters and attributes */
 		/*-------------OCIInitialize Modes / OCICreateEnvironment Modes -------------*/

--- a/oci8.c
+++ b/oci8.c
@@ -1127,7 +1127,7 @@ dbd_phs_in(dvoid *octxp, OCIBind *bindp, ub4 iter, ub4 index,
 			phs->alen = 0;
 			phs->indp = 0;
 		}
-	else
+		else
 			if (SvOK(phs->sv)) {
 				*bufpp  = SvPV(phs->sv, phs_len);
 				phs->alen = (phs->alen_incnull) ? phs_len+1 : phs_len;;
@@ -1138,20 +1138,20 @@ dbd_phs_in(dvoid *octxp, OCIBind *bindp, ub4 iter, ub4 index,
 				phs->alen = 0;
 				phs->indp = -1;
 			}
-			*alenp  = phs->alen;
-			*indpp  = &phs->indp;
-			*piecep = OCI_ONE_PIECE;
-            /* MJE commented out as we are avoiding DBIS now but as this is
-               an Oracle callback there is no way to pass something non
-               OCI into this func.
+	*alenp  = phs->alen;
+	*indpp  = &phs->indp;
+	*piecep = OCI_ONE_PIECE;
+	/* MJE commented out as we are avoiding DBIS now but as this is
+	   an Oracle callback there is no way to pass something non
+	   OCI into this func.
 
-			if (DBIS->debug >= 3 || dbd_verbose >= 3 )
-				PerlIO_printf(DBILOGFP, "		in  '%s' [%lu,%lu]: len %2lu, ind %d%s, value=%s\n",
-					phs->name, ul_t(iter), ul_t(index), ul_t(phs->alen), phs->indp,
-					(phs->desc_h) ? " via descriptor" : "",neatsvpv(phs->sv,10));
-            */
-			if (!tuples_av && (index > 0 || iter > 0))
-				croak(" Arrays and multiple iterations not currently supported by DBD::Oracle (in %d/%d)", index,iter);
+	if (DBIS->debug >= 3 || dbd_verbose >= 3 )
+		PerlIO_printf(DBILOGFP, "		in  '%s' [%lu,%lu]: len %2lu, ind %d%s, value=%s\n",
+			phs->name, ul_t(iter), ul_t(index), ul_t(phs->alen), phs->indp,
+			(phs->desc_h) ? " via descriptor" : "",neatsvpv(phs->sv,10));
+	*/
+	if (!tuples_av && (index > 0 || iter > 0))
+		croak(" Arrays and multiple iterations not currently supported by DBD::Oracle (in %d/%d)", index,iter);
 
 	return OCI_CONTINUE;
 }
@@ -1842,7 +1842,7 @@ ora_blob_read_mb_piece(SV *sth, imp_sth_t *imp_sth, imp_fbh_t *fbh,
 	if (dbis->debug >= 3 || dbd_verbose >= 3 )
 		PerlIO_printf(
             DBIc_LOGPIO(imp_sth),
-            "	blob_read field %d, ftype %d, offset %ld, len %lu, "
+            "	blob_read field %d, ftype %d, offset %ld, len %u, "
             "destoffset %ld, retlen %lu\n",
 			fbh->field_num+1, ftype, offset, len, destoffset, ul_t(amtp));
 

--- a/ocitrace.h
+++ b/ocitrace.h
@@ -59,8 +59,8 @@
 					 "%sOCISessionPoolDestroy(ph=%p)=%s\n",\
 					 OciTp, ph,oci_status_name(stat)),stat \
 	: stat
-#define OCISessionGet_log_stat(impdbh,envhp,errhp,sh,ah,pn,pnl,tag,tagl,found,stat) \
-	stat =OCISessionGet(envhp, errhp, sh, ah,pn,pnl,tag,tagl, NULL, NULL, found, OCI_SESSGET_SPOOL);\
+#define OCISessionGet_log_stat(impdbh,envhp,errhp,sh,ah,pn,pnl,tag,tagl,rettag,rettagl,found,stat) \
+	stat =OCISessionGet(envhp, errhp, sh, ah,pn,pnl,tag,tagl,rettag,rettagl,found, OCI_SESSGET_SPOOL);\
 	(DBD_OCI_TRACEON(impdbh))                                          \
     ? PerlIO_printf(DBD_OCI_TRACEFP(impdbh),                           \
 					 "%sOCISessionGet(envhp=%p,sh=%p,ah=%p,pn=%p,pnl=%d,tag=\"%s\",found=%d)=%s\n",\

--- a/ocitrace.h
+++ b/ocitrace.h
@@ -44,12 +44,12 @@
 				 OciTp, sc,oci_status_name(stat)),stat \
 	: stat
 
-#define OCISessionRelease_log_stat(impdbh,svchp, errhp,stat)            \
-	stat =OCISessionRelease(svchp, errhp, NULL, (ub4)0, OCI_DEFAULT);\
+#define OCISessionRelease_log_stat(impdbh,svchp,errhp,tag,tagl,mode,stat)	\
+	stat =OCISessionRelease(svchp, errhp, tag, tagl, mode);\
 	(DBD_OCI_TRACEON(impdbh))                                       \
     ? PerlIO_printf(DBD_OCI_TRACEFP(impdbh),                             \
-						 "%sOCISessionRelease(svchp=%p)=%s\n",\
-						 OciTp, svchp,oci_status_name(stat)),stat \
+						 "%sOCISessionRelease(svchp=%p,tag=\"%s\",mode=%u)=%s\n",\
+						 OciTp, svchp,tag,mode,oci_status_name(stat)),stat	\
 	: stat
 
 #define OCISessionPoolDestroy_log_stat(impdbh, ph, errhp,stat )  \
@@ -59,20 +59,20 @@
 					 "%sOCISessionPoolDestroy(ph=%p)=%s\n",\
 					 OciTp, ph,oci_status_name(stat)),stat \
 	: stat
-#define OCISessionGet_log_stat(impdbh,envhp, errhp, sh, ah,pn,pnl,stat) \
-	stat =OCISessionGet(envhp, errhp, sh, ah,pn,pnl,NULL,0, NULL, NULL, NULL, OCI_SESSGET_SPOOL);\
+#define OCISessionGet_log_stat(impdbh,envhp,errhp,sh,ah,pn,pnl,tag,tagl,found,stat) \
+	stat =OCISessionGet(envhp, errhp, sh, ah,pn,pnl,tag,tagl, NULL, NULL, found, OCI_SESSGET_SPOOL);\
 	(DBD_OCI_TRACEON(impdbh))                                          \
     ? PerlIO_printf(DBD_OCI_TRACEFP(impdbh),                           \
-					 "%sOCISessionGet(envhp=%p,sh=%p,ah=%p,pn=%p,pnl=%d)=%s\n",\
-					 OciTp, envhp,sh,ah,pn,pnl,oci_status_name(stat)),stat \
+					 "%sOCISessionGet(envhp=%p,sh=%p,ah=%p,pn=%p,pnl=%d,tag=\"%s\",found=%d)=%s\n",\
+					 OciTp, envhp,sh,ah,pn,pnl,tag,*found,oci_status_name(stat)),stat \
 	: stat
 
-#define OCISessionPoolCreate_log_stat(impdbh,envhp,errhp,ph,pn,pnl,dbn,dbl,sn,sm,si,un,unl,pw,pwl,stat) \
-    stat =OCISessionPoolCreate(envhp,errhp,ph,pn,pnl,dbn,dbl,sn,sm,si,un,unl,pw,pwl,OCI_DEFAULT);\
+#define OCISessionPoolCreate_log_stat(impdbh,envhp,errhp,ph,pn,pnl,dbn,dbl,sn,sm,si,un,unl,pw,pwl,mode,stat) \
+    stat =OCISessionPoolCreate(envhp,errhp,ph,pn,pnl,dbn,dbl,sn,sm,si,un,unl,pw,pwl,mode);\
     (DBD_OCI_TRACEON(impdbh))                                          \
     ? PerlIO_printf(DBD_OCI_TRACEFP(impdbh),                           \
-					 "%sOCISessionPoolCreate(envhp=%p,ph=%p,pn=%p,pnl=%p,min=%d,max=%d,incr=%d, un=%s,unl=%d,pw=%s,pwl=%d)=%s\n",\
-					 OciTp, envhp,ph,pn,pnl,sn,sm,si,un,unl,pw,pwl,oci_status_name(stat)),stat \
+					 "%sOCISessionPoolCreate(envhp=%p,ph=%p,pn=%p,pnl=%p,min=%d,max=%d,incr=%d, un=%s,unl=%d,pw=%s,pwl=%d,mode=%u)=%s\n",\
+					 OciTp, envhp,ph,pn,pnl,sn,sm,si,un,unl,pw,pwl,mode,oci_status_name(stat)),stat \
 	: stat
 
 #if defined(ORA_OCI_102)

--- a/t/14threads.t
+++ b/t/14threads.t
@@ -181,7 +181,7 @@ sub connect_dbh {
 
 sub session_id {
     my $dbh = shift;
-    my ($s) = $dbh->selectrow_array("select userenv('sessionid') from dual");
+    my ($s) = $dbh->selectrow_array("select userenv('sid') from dual");
     return $s;
 }
 __END__

--- a/t/31lob.t
+++ b/t/31lob.t
@@ -212,6 +212,8 @@ END_SQL
     }
 }
 
+undef $sth;
+
 $dbh->do("DROP TABLE $table");
 $dbh->disconnect;
 


### PR DESCRIPTION
Server side DRCP sessions are now actually shared, and reauthentication on every connect is avoided. Subsequent connects via DRCP are now up to several hundred times faster than before.

Various fixes for compiler warnings, OCI handle leaks, and OCI programming errors.

Support for Oracle Fast Application Notification (FAN).

This work was sponsored by EVRY Information Services.
