### PR TITLE
https://lintian.debian.org/tags/spelling-error-in-manpage.html etc

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -407,7 +407,7 @@ dbd_db_login6(SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, char *pwd, S
 	if (DBD_ATTRIB_TRUE(attr,"ora_drcp",8,svp))
 		imp_dbh->using_drcp = 1;
 
-	/* some connection pool atributes  */
+	/* some connection pool attributes  */
 
 	if ((svp=DBD_ATTRIB_GET_SVP(attr, "ora_drcp_class", 14)) && SvOK(*svp)) {
 		STRLEN  svp_len;
@@ -2819,7 +2819,7 @@ pp_exec_rset(SV *sth, imp_sth_t *imp_sth, phs_t *phs, int pre_exec)
         {
             D_impdata(imp_sth_csr, imp_sth_t, sth_csr); /* TO_DO */
 
-            /* copy appropriate handles and atributes from parent statement	*/
+            /* copy appropriate handles and attributes from parent statement	*/
             imp_sth_csr->envhp		= imp_sth->envhp;
             imp_sth_csr->errhp		= imp_sth->errhp;
             imp_sth_csr->srvhp		= imp_sth->srvhp;

--- a/lib/DBD/Oracle.pm
+++ b/lib/DBD/Oracle.pm
@@ -4929,7 +4929,7 @@ The following code will access the data;
    print $obj1->attr('NAME')."3\n";   # 'Black' is printed
    print $obj2->attr('NAME')."3\n";   # 'Smith' is printed
 
-   # get all atributes as hash reference
+   # get all attributes as hash reference
    my $h1 = $obj1->attr;        # returns {'NAME' => 'Black', 'AGE' => 25}
    my $h2 = $obj2->attr;        # returns {'NAME' => 'Smith', 'AGE' => 44,
                                 #          'SALARY' => 5000 }
@@ -5441,7 +5441,7 @@ to dbd-oracle-changes-subscribe@perl.org after which you'll get an email with th
 change log message and diff of each change checked-in to the source.
 
 After making your changes you can generate a patch file, but before
-you do, make sure your source is still upto date using:
+you do, make sure your source is still up-to-date using:
 
   svn update
 

--- a/lib/DBD/Oracle/Troubleshooting/Aix.pod
+++ b/lib/DBD/Oracle/Troubleshooting/Aix.pod
@@ -145,7 +145,7 @@ Stephen de Vries
         ORACLE_USERID..
         ORACLE_SID ..
 
-    -Run make, all tests should be successfull -against Oracle 9.x at least.
+    -Run make, all tests should be successful -against Oracle 9.x at least.
 
     You should have no problems with Oracle 8.1.7, but accessing Oracle 7.x
     or previous is not possible (you'll core dump, or simply hang). The same

--- a/lib/DBD/Oracle/Troubleshooting/Hpux.pod
+++ b/lib/DBD/Oracle/Troubleshooting/Hpux.pod
@@ -190,7 +190,7 @@ Perl from source, the Configure program will ask you a series of
 questions about how to build Perl.  You may supply default answers to the
 questions when you invoke the Configure program by command line flags.
 
-We want to build a Perl that understands large files (over 2GB, wich is
+We want to build a Perl that understands large files (over 2GB, which is
 the default for building perl on HP-UX), and that is incompatible with
 v5.005 Perl scripts (compiling with v5.005 compatibility causes mod_perl
 to complain about malloc pollution).  At the command prompt type:
@@ -856,7 +856,7 @@ warnings;". However, it was annoying, since all my scripts had -w in the
 
 Since almost every OS now supports dynamic linking, I believe that static
 linking is NOT getting the same level of vetting it maybe used to.
-Dynamicly linking is what you get by default, so its way better tested.
+Dynamically linking is what you get by default, so its way better tested.
 
 =item 5 It's required for Apache and mod_perl.
 

--- a/lib/DBD/Oracle/Troubleshooting/Win32.pod
+++ b/lib/DBD/Oracle/Troubleshooting/Win32.pod
@@ -87,7 +87,7 @@ Windows platform having no Oracle or other development environment installed.
 
     12) Open a Windows Visual C++ command window from the start menu.
 
-    13) Add the path to the instant client to the Path command. If you are compiling aginst a 10XE db/client then you can skip steps 
+    13) Add the path to the instant client to the Path command. If you are compiling against a 10XE db/client then you can skip steps 
         12 to 14. 
         e.g.  PATH = C:/Oracle/instantclient;%PATH%
     
@@ -127,7 +127,7 @@ Windows platform having no Oracle or other development environment installed.
             iii. Attempt to log into the version of SQLPLUS that comes with Instantclient.  
                         If you manage to log on use the username password and TNS name with 
                         the Set ORACLE_USERID = and rerun the tests.
-                    iv   If you are compiling against 10XE and have skiped steps 12 to 14 try again bu this time carry out these steps
+                    iv   If you are compiling against 10XE and have skipped steps 12 to 14 try again bu this time carry out these steps
 
     20) You can now install DBD-Oracle into you system by entering the following command from the Visual C++ window dos prompt;
 

--- a/oci8.c
+++ b/oci8.c
@@ -2564,7 +2564,7 @@ the concept is simple really
 	The the obj_ind is for the entier object not the properties so you call it once it
 	gets all of the indicators for the objects so you pass it into OCIObjectGetAttr and that
 	function will set attr_null_status as in the get below.
- 5. interate over the atributes of the object
+ 5. interate over the attributes of the object
 
 The thing to remember is that OCI and C have no way of representing a DB NULLs so we use the OCIInd find out
 if the object or any of its properties are NULL, This is one little line in a 20 chapter book and even then


### PR DESCRIPTION
a couple of spelling errors get mentioned here:
* https://lintian.debian.org/full/pkg-perl-maintainers@lists.alioth.debian.org.html#libdbd-oracle-perl_1.74-4

it's trivial and easy to get rid of them.