### PR TITLE
Improve finding ORACLE_HOME when installing on Linux OS

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -979,6 +979,13 @@ sub find_oracle_home {
 	@oh = grep { (glob("$_/../lib*/libclntsh.$so*"))[0] } @path;
 	s:/[^/]/?$:: for @oh;
     }
+    if (!@oh && lc($^O) eq 'linux') { # Try the standard Linux RPM location
+   my @loh = glob("/usr/lib/oracle/*/*/lib/libclntsh.$so*");
+   @loh = sort { $a cmp $b } @loh;
+   my $loh = pop(@loh);
+   $loh =~ s/\/lib\/libclntsh.*$//g;
+   push(@oh,$loh);
+    }
     print "Found @oh\n" if @oh;
     return $oh[0];
 }
@@ -1691,6 +1698,9 @@ sub get_client_version {
 	elsif ( "$OH/" =~ m!/10g!) { # scary but handy
 	    $client_version_full = "10.0.0.0";
 	}
+   elsif ( "$OH/" =~ m!/usr/lib/oracle/(\d+\.\d)/!) { # Linux RPM
+       $client_version_full = "$1.0.0";
+   }
     }
 
     if ($force_version && $force_version ne $client_version_full) {


### PR DESCRIPTION
These additional checks makes it to where if you installed Instant Client from the RPMs (basic and devel), then Makefile.PL will pick it and the correct (and highest if there are multiple) version without ORACLE_HOME being set. Setting ORACLE_HOME or LD_LIBRARY_PATH will grab the version from the path.

This patch is probably best paired with DBI 1.623 requirement since DBI 1.623+ allows for LD_LIBRARY_PATH to not be set at all.

This is a redo of pull request #71.

This resolves issue #68.


