### PR TITLE
correct the type passed to OCIAttrGet() for OCI_ATTR_TAF_ENABLED

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4776,7 +4776,7 @@ static int enable_taf(
     SV *dbh,
     imp_dbh_t *imp_dbh) {
 
-    bool can_taf = 0;
+    boolean can_taf = 0;
     sword status;
 
 #ifdef OCI_ATTR_TAF_ENABLED


### PR DESCRIPTION
should fix #35 

I haven't been able to test this beyond compiling it.