### PR TITLE
Move freeing global envhp to destruction of last dbh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
     - AUTOMATED_TESTING=1
     - EXTENDED_TESTING=1
     - RELEASE_TESTING=0
+    - TRAVIS_PERL_DEBUG=1
+    - HELPERS_DEBUG=1
     - CFLAGS="-g -O2 -fstack-protector -Wformat -Werror=format-security"
     - CPPFLAGS="-D_FORTIFY_SOURCE=2"
     - CXXFLAGS="-g -O2 -fstack-protector -Wformat -Werror=format-security"


### PR DESCRIPTION
**This pull request is for testing only - please don't merge** 

As the order of object destruction during "global destruction" is
undefined. DBI traces show that the global environment is freed in the
driver destruction process before all database connections are closed
and their resources freed. This causes the segfault in #65.

This change moved freeing of the global environment handle from the
destruction of the driver handle (dbd_dr_destroy()) to the destruction
of the database handle (dbd_db_destroy()).

This implementation closes the global environment handle during the DBI
shutdown process if the last database handle uses the global
environment handle.

If the last database handles uses a session environment handle, the
global environment handle will not be destroyed.