### PR TITLE
Build DBD::Oracle on Debian systems without LD_LIBRARY_PATH

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1114,7 +1114,9 @@ sub read_sysliblist {
        $linkwith =~ m/-lcl\b/ or
            $syslibs =~ s/\s*-lcl\b//g;
     }
-    $syslibs .= " -lnnz12 -lons -lclntshcore -lipc1 -lmql1";
+    if (lc(@Config{qw(myuname)}) =~ /debian/) {
+        $syslibs .= " -lnnz12 -lons -lclntshcore -lipc1 -lmql1";
+    }
     return $syslibs;
 }
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1115,7 +1115,7 @@ sub read_sysliblist {
            $syslibs =~ s/\s*-lcl\b//g;
     }
     if (lc(@Config{qw(myuname)}) =~ /debian/) {
-        $syslibs .= " -lnnz12 -lons -lclntshcore -lipc1 -lmql1";
+        $syslibs .= " -Wl,--no-as-needed -lnnz12 -lons -lclntshcore -lipc1 -lmql1";
     }
     return $syslibs;
 }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1114,6 +1114,7 @@ sub read_sysliblist {
        $linkwith =~ m/-lcl\b/ or
            $syslibs =~ s/\s*-lcl\b//g;
     }
+    $syslibs .= " -lnnz12 -lons -lclntshcore -lipc1 -lmql1";
     return $syslibs;
 }
 


### PR DESCRIPTION
Patch based on a proposed fix by Slaven Rezić <eserte> in https://github.com/perl5-dbi/DBD-Oracle/issues/72 and improved by me afterwards.

The patch has been successfully applied to Debian for a few releases now:

https://salsa.debian.org/perl-team/modules/packages/libdbd-oracle-perl/blob/master/debian/patches/build-without-ld-libray-path.patch

Closes: #72
 