### PR TITLE
Have the 25plsql.t test for 'bind_param_inout for non assigned' warn

### DIFF
--- a/t/25plsql.t
+++ b/t/25plsql.t
@@ -30,7 +30,7 @@ if ($dbh) {
         plan skip_all =>
 'Oracle server either does not support pl/sql or it is not properly installed';
     }
-    plan tests => 82;
+    plan tests => 79;
 }
 else {
     plan skip_all => "Unable to connect to Oracle \n";
@@ -346,9 +346,9 @@ END ;)
     $sth->bind_param_inout( ':p3', \$p3, 1 );
     note("Before p1=[$p1] p2=[$p2] p3=[$p3]\n");
     ok( $sth->execute, 'test bind_param_inout for non assigned' );
-    is( $p1, 'Hello', 'p1 ok' );
-    is( $p2, 'Y',     'p2 ok' );
-    is( $p3, 'Y',     'p3 ok' );
+    if ($p1 ne 'Hello' or $p2 ne 'Y' or $p3 ne 'Y') {
+      warn "PL/SQL OUT binds should be initialized in the PL/SQL block";
+    }
     note("After p1=[$p1] p2=[$p2] p3=[$p3]\n");
 }
 


### PR DESCRIPTION
rather than fail when client version needs OUT binds to be
initialized first. Issue #70.