### PR TITLE
Have find_headers() also search for header files based off the

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1541,6 +1541,8 @@ sub find_headers {
 
     # compensate for case where final .0 isn't in the install directory name
     (my $client_version_trim = $client_version_full) =~ s/\.0$//;
+    # for case where point is not in install directory name. OCI 21+
+    (my $client_version_major = $client_version) =~ s/\..*$//;
 
     my @try = grep { -d $_ } ( # search the ORACLE_HOME we're using first
        # --- Traditional full-install locations
@@ -1557,15 +1559,19 @@ sub find_headers {
            $client_version,
            $client_version_trim,
            $client_version_full,
+           $client_version_major,
 
        #"/include/oracle/$client_version_full/client",       # Instant Client for RedHat FC3
        #"/include/oracle/$client_version_trim/client",       # Instant Client for RedHat FC3
+       #"/include/oracle/$client_version_major/client",      # Instant Client RPM (21+)
        #"/usr/include/oracle/$client_version/client64",      # Instant Client 11.1 and up
        #"/usr/include/oracle/$client_version/client",        # Instant Client 11.1 and up
        #"/usr/include/oracle/$client_version_full/client64", # Instant Client 64
        #"/usr/include/oracle/$client_version_full/client",   # Instant Client for RedHat FC4
        #"/usr/include/oracle/$client_version_trim/client64", # Instant Client 64
+       #"/usr/include/oracle/$client_version_major/client64",# Instant Client RPM (21+)
        #"/usr/include/oracle/$client_version_trim/client",   # Instant Client for RedHat FC4
+       #"/usr/include/oracle/$client_version_major/client",  # Instant Client RPM (21+)
     );
 
    # Add /usr/include/oracle based on the oracle home location if oracle home is under


### PR DESCRIPTION
major version number.

The following has always been supported (note the /lib):
ORACLE_HOME=/usr/lib/oracle/21/client64/lib

As of Instant Client 21 this will fail with "can't find the header files" since find_headers() does not account for major version number only in the path. This was somewhat talked about/fixed in GH#127.

The above isn't however an issue if you leave /lib out of the ORACLE_HOME. But like I said it was never an issue before 21.

The fix is to have find_headers() also look for paths with the major number only. This helps the search for headers in general.

It also fixes not setting ORACLE_HOME at all (which is also supported if LD_LIBARY_PATH is set).

