### PR TITLE
PR for GH#111

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for DBD::Oracle
 
 {{$NEXT}}
 
+  Big patch that should fix the crash if disconnect not called - (GH#111, Andrey Voropaev)
   Have find_headers() also search for header files based off the major version number - (GH#142, Wesley Hinds)
   Check for appropriate permissions before running 56embbeded.t tests - (#143, Wesley Hinds)
   Updated links in doc in Oracle.pm - (Gh#145, kjetillll)

--- a/Oracle.h
+++ b/Oracle.h
@@ -26,7 +26,7 @@
 #endif
 
 /* egcs-1.1.2 does not have _int64 */
-#if defined(__MINGW32__) || defined(__CYGWIN32__)
+#if defined(__MINGW32__) || defined(__CYGWIN32__) || defined(__CYGWIN__)
 #define _int64 long long
 #endif
 

--- a/Oracle.xs
+++ b/Oracle.xs
@@ -104,7 +104,7 @@ ora_env_var(name)
 		sv_setpv(sv, p);
 	ST(0) = sv;
 
-#if defined(__CYGWIN32__) || defined(__CYGWIN64__)
+#if defined(__CYGWIN32__) || defined(__CYGWIN64__) || defined(__CYGWIN__)
 void
 ora_cygwin_set_env(name, value)
 	char * name
@@ -485,7 +485,7 @@ ora_lob_write(dbh, locator, offset, data)
 	}
 #endif /* OCI_ATTR_CHARSET_ID */
 	/* if data is utf8 but charset isn't then switch to utf8 csid */
-	csid = (SvUTF8(data) && !CS_IS_UTF8(csid)) ? utf8_csid : CSFORM_IMPLIED_CSID(csform);
+	csid = (SvUTF8(data) && !CS_IS_UTF8(csid)) ? utf8_csid : CSFORM_IMPLIED_CSID(imp_dbh, csform);
 
 	OCILobWrite_log_stat(imp_dbh, imp_dbh->svchp, imp_dbh->errhp, locator,
 		&amtp, (ub4)offset,
@@ -546,7 +546,7 @@ ora_lob_append(dbh, locator, data)
 	}
 #endif /* OCI_ATTR_CHARSET_ID */
 	/* if data is utf8 but charset isn't then switch to utf8 csid */
-	csid = (SvUTF8(data) && !CS_IS_UTF8(csid)) ? utf8_csid : CSFORM_IMPLIED_CSID(csform);
+	csid = (SvUTF8(data) && !CS_IS_UTF8(csid)) ? utf8_csid : CSFORM_IMPLIED_CSID(imp_dbh, csform);
 	OCILobWriteAppend_log_stat(imp_dbh, imp_dbh->svchp, imp_dbh->errhp, locator,
 				   &amtp, bufp, (ub4)data_len, OCI_ONE_PIECE,
 				   NULL, NULL,
@@ -625,7 +625,7 @@ ora_lob_read(dbh, locator, offset, length)
             SvCUR(dest_sv) = amtp; /* always bytes here */
             *SvEND(dest_sv) = '\0';
             if (csform){
-                if (CSFORM_IMPLIES_UTF8(csform)){
+                if (CSFORM_IMPLIES_UTF8(imp_dbh, csform)){
                     SvUTF8_on(dest_sv);
                 }
             }

--- a/oci8.c
+++ b/oci8.c
@@ -15,6 +15,7 @@
 #include <utf8.h>
 #endif
 
+#undef sv_set_undef
 #define sv_set_undef(sv) if (SvROK(sv)) sv_unref(sv); else SvOK_off(sv)
 
 DBISTATE_DECLARE;
@@ -879,15 +880,28 @@ oci_error_err(SV *h, OCIError *errhp, sword status, char *what, sb4 force_err)
 	dTHX;
 	D_imp_xxh(h);
 	sb4 errcode;
+        int utf8_is_implied = 0;
 	SV *errstr_sv = sv_newmortal();
 	SV *errcode_sv = sv_newmortal();
 	errcode = oci_error_get(imp_xxh, errhp, status, what, errstr_sv,
                             DBIc_DBISTATE(imp_xxh)->debug);
-	if (CSFORM_IMPLIES_UTF8(SQLCS_IMPLICIT)) {
+
+        if(DBIc_TYPE(imp_xxh) == DBIt_ST)
+        {
+            imp_sth_t * imp_sth = (imp_sth_t*)imp_xxh;
+            D_imp_dbh_from_sth;
+            utf8_is_implied = CSFORM_IMPLIES_UTF8(imp_dbh, SQLCS_IMPLICIT);
+        }
+        else if(DBIc_TYPE(imp_xxh) == DBIt_DB)
+            utf8_is_implied = CSFORM_IMPLIES_UTF8((imp_dbh_t *)imp_xxh, SQLCS_IMPLICIT);
+        else if(DBIc_TYPE(imp_xxh) == DBIt_DR)
+            utf8_is_implied = CSFORM_IMPLIES_UTF8((imp_drh_t *)imp_xxh, SQLCS_IMPLICIT);
+
+	if (utf8_is_implied) {
 #ifdef sv_utf8_decode
-	sv_utf8_decode(errstr_sv);
+            sv_utf8_decode(errstr_sv);
 #else
-	SvUTF8_on(errstr_sv);
+            SvUTF8_on(errstr_sv);
 #endif
 	}
 
@@ -1468,7 +1482,7 @@ fetch_func_varfield(SV *sth, imp_fbh_t *fbh, SV *dest_sv)
 			}
 	}
 	sv_setpvn(dest_sv, p, (STRLEN)datalen);
-	if (CSFORM_IMPLIES_UTF8(fbh->csform))
+	if (CSFORM_IMPLIES_UTF8(imp_dbh, fbh->csform))
 		SvUTF8_on(dest_sv);
 	} else {
 #else
@@ -1717,7 +1731,7 @@ dbd_rebind_ph_lob(SV *sth, imp_sth_t *imp_sth, phs_t *phs)
 					return oci_error(sth, imp_sth->errhp, status, "OCILobCharSetId");
 #endif /* OCI_ATTR_CHARSET_ID */
 		/* if data is utf8 but charset isn't then switch to utf8 csid */
-				csid = (SvUTF8(phs->sv) && !CS_IS_UTF8(csid)) ? utf8_csid : CSFORM_IMPLIED_CSID(csform);
+				csid = (SvUTF8(phs->sv) && !CS_IS_UTF8(csid)) ? utf8_csid : CSFORM_IMPLIED_CSID(imp_dbh, csform);
 				phs->csid = csid;
 				phs->csform = csform;
 			}
@@ -1748,6 +1762,7 @@ ora_blob_read_mb_piece(SV *sth, imp_sth_t *imp_sth, imp_fbh_t *fbh,
   SV *dest_sv, long offset, ub4 len, long destoffset)
 {
 	dTHX;
+	D_imp_dbh_from_sth;
 	ub4 loblen = 0;
 	ub4 buflen;
 	ub4 amtp = 0;
@@ -1853,7 +1868,7 @@ ora_blob_read_mb_piece(SV *sth, imp_sth_t *imp_sth, imp_fbh_t *fbh,
 	SvCUR_set(dest_sv, byte_destoffset+amtp);
 	*SvEND(dest_sv) = '\0'; /* consistent with perl sv_setpvn etc	*/
 	SvPOK_on(dest_sv);
-	if (ftype == ORA_CLOB && CSFORM_IMPLIES_UTF8(csform))
+	if (ftype == ORA_CLOB && CSFORM_IMPLIES_UTF8(imp_dbh, csform))
 		SvUTF8_on(dest_sv);
 
 	return 1;
@@ -1865,6 +1880,7 @@ ora_blob_read_piece(SV *sth, imp_sth_t *imp_sth, imp_fbh_t *fbh, SV *dest_sv,
 			long offset, UV len, long destoffset)
 {
 	dTHX;
+	D_imp_dbh_from_sth;
 	ub4 loblen	= 0;
 	ub4 buflen;
 	ub4 amtp 	= 0;
@@ -1929,7 +1945,7 @@ ora_blob_read_piece(SV *sth, imp_sth_t *imp_sth, imp_fbh_t *fbh, SV *dest_sv,
 	/* so for CLOBs that'll be returned as UTF8 we need more bytes that chars */
 	/* XXX the x4 here isn't perfect - really the code should be changed to loop */
 
-	if (ftype == ORA_CLOB && CSFORM_IMPLIES_UTF8(csform)) {
+	if (ftype == ORA_CLOB && CSFORM_IMPLIES_UTF8(imp_dbh, csform)) {
 		buflen = amtp * 4;
 	/* XXX destoffset would be counting chars here as well */
 		SvGROW(dest_sv, (destoffset*4) + buflen + 1);
@@ -1972,7 +1988,7 @@ ora_blob_read_piece(SV *sth, imp_sth_t *imp_sth, imp_fbh_t *fbh, SV *dest_sv,
 			sv_set_undef(dest_sv);	/* signal error */
 			return 0;
 		}
-		if (ftype == ORA_CLOB && CSFORM_IMPLIES_UTF8(csform))
+		if (ftype == ORA_CLOB && CSFORM_IMPLIES_UTF8(imp_dbh, csform))
 			SvUTF8_on(dest_sv);
 	}
 	else {
@@ -2003,6 +2019,7 @@ static int
 fetch_lob(SV *sth, imp_sth_t *imp_sth, OCILobLocator* lobloc, int ftype, SV *dest_sv, char *name)
 {
 	dTHX;
+	D_imp_dbh_from_sth;
 	ub4 loblen	= 0;
 	ub4 buflen	= 0;
 	ub4 amtp 	= 0;
@@ -2155,9 +2172,9 @@ fetch_lob(SV *sth, imp_sth_t *imp_sth, OCILobLocator* lobloc, int ftype, SV *des
 	/* tell perl what we've put in its dest_sv */
 	SvCUR(dest_sv) = amtp;
 	*SvEND(dest_sv) = '\0';
-	if (ftype == ORA_CLOB && CSFORM_IMPLIES_UTF8(csform)) /* Don't set UTF8 on BLOBs */
+        if (ftype == ORA_CLOB && CSFORM_IMPLIES_UTF8(imp_dbh, csform)) /* Don't set UTF8 on BLOBs */
  		SvUTF8_on(dest_sv);
-		ora_free_templob(sth, imp_sth, lobloc);
+        ora_free_templob(sth, imp_sth, lobloc);
 	}
 	else {			/* LOB length is 0 */
 		assert(amtp == 0);
@@ -2321,8 +2338,8 @@ static void get_attr_val(SV *sth,AV *list,imp_fbh_t *fbh, text  *name , OCITypeC
                                    status);
 
 		if (typecode == OCI_TYPECODE_TIMESTAMP_TZ || typecode == OCI_TYPECODE_TIMESTAMP_LTZ){
-			char s_tz_hour[3]="000";
-			char s_tz_min[3]="000";
+			char s_tz_hour[6]="000";
+			char s_tz_min[6]="000";
 			sb1 tz_hour;
 			sb1 tz_minute;
 			status = OCIDateTimeGetTimeZoneOffset (fbh->imp_sth->envhp,
@@ -2694,7 +2711,7 @@ static int
 fetch_func_oci_object(SV *sth, imp_fbh_t *fbh,SV *dest_sv)
 {
 	dTHX;
-    D_imp_sth(sth);
+        D_imp_sth(sth);
 
 	if (DBIc_DBISTATE(imp_sth)->debug >= 4 || dbd_verbose >= 4 ) {
 		PerlIO_printf(DBIc_LOGPIO(imp_sth),
@@ -2726,6 +2743,7 @@ fetch_clbk_lob(SV *sth, imp_fbh_t *fbh,SV *dest_sv){
 
 	dTHX;
 	D_imp_sth(sth);
+	D_imp_dbh_from_sth;
 	fb_ary_t *fb_ary = fbh->fb_ary;
 
 	ub4 actual_bufl=imp_sth->piece_size*(fb_ary->piece_count)+fb_ary->bufl;
@@ -2756,7 +2774,7 @@ fetch_clbk_lob(SV *sth, imp_fbh_t *fbh,SV *dest_sv){
 		sv_setpvn(dest_sv, (char*)fb_ary->cb_abuf,(STRLEN)actual_bufl);
 	} else {
 		sv_setpvn(dest_sv, (char*)fb_ary->cb_abuf,(STRLEN)actual_bufl);
-		if (CSFORM_IMPLIES_UTF8(fbh->csform) ){
+		if (CSFORM_IMPLIES_UTF8(imp_dbh, fbh->csform) ){
 			SvUTF8_on(dest_sv);
 		}
 	}
@@ -2769,6 +2787,7 @@ fetch_get_piece(SV *sth, imp_fbh_t *fbh,SV *dest_sv)
 {
 	dTHX;
 	D_imp_sth(sth);
+	D_imp_dbh_from_sth;
 	fb_ary_t *fb_ary = fbh->fb_ary;
 	ub4 buflen		 = fb_ary->bufl;
 	ub4 actual_bufl	 = 0;
@@ -2859,7 +2878,7 @@ fetch_get_piece(SV *sth, imp_fbh_t *fbh,SV *dest_sv)
 		sv_setpvn(dest_sv, (char*)fb_ary->cb_abuf,(STRLEN)actual_bufl);
 		if (fbh->ftype != SQLT_BIN){
 
-			if (CSFORM_IMPLIES_UTF8(fbh->csform) ){ /* do the UTF 8 magic*/
+			if (CSFORM_IMPLIES_UTF8(imp_dbh, fbh->csform) ){ /* do the UTF 8 magic*/
 				SvUTF8_on(dest_sv);
 			}
 		}
@@ -3554,7 +3573,7 @@ dbd_describe(SV *h, imp_sth_t *imp_sth)
             avg_width = fbh->dbsize / 2;
             /* FALLTHRU */
           case	ORA_CHAR:				/* CHAR		*/
-            if ( CSFORM_IMPLIES_UTF8(fbh->csform) && !CS_IS_UTF8(fbh->csid) )
+            if ( CSFORM_IMPLIES_UTF8(imp_dbh, fbh->csform) && !CS_IS_UTF8(fbh->csid) )
                 fbh->disize = fbh->dbsize * 4;
             else
                 fbh->disize = fbh->dbsize;
@@ -3616,7 +3635,7 @@ dbd_describe(SV *h, imp_sth_t *imp_sth)
             }
             else {
 
-                if ( CSFORM_IMPLIES_UTF8(fbh->csform) && !CS_IS_UTF8(fbh->csid) )
+                if ( CSFORM_IMPLIES_UTF8(imp_dbh, fbh->csform) && !CS_IS_UTF8(fbh->csid) )
                     fbh->disize = long_readlen * 4;
                 else
                     fbh->disize = long_readlen;
@@ -4194,7 +4213,7 @@ dbd_st_fetch(SV *sth, imp_sth_t *imp_sth){
 								fbh->req_type, i+1);
                             /* issue warning */
                             DBIh_SET_ERR_CHAR(sth, imp_xxh, "0", 1, errstr, Nullch, Nullch);
-                            if (CSFORM_IMPLIES_UTF8(fbh->csform) ){
+                            if (CSFORM_IMPLIES_UTF8(imp_dbh, fbh->csform) ){
                                 SvUTF8_on(sv);
                             }
 						}
@@ -4202,7 +4221,7 @@ dbd_st_fetch(SV *sth, imp_sth_t *imp_sth){
 					else
 #endif /* DBISTATE_VERSION > 94 */
 					{
-						if (CSFORM_IMPLIES_UTF8(fbh->csform) ){
+						if (CSFORM_IMPLIES_UTF8(imp_dbh, fbh->csform) ){
 							SvUTF8_on(sv);
 						}
 					}
@@ -4222,7 +4241,7 @@ dbd_st_fetch(SV *sth, imp_sth_t *imp_sth){
 					/* Copy the truncated value anyway, it may be of use,	*/
 					/* but it'll only be accessible via prior bind_column()	*/
 					sv_setpvn(sv, (char *)row_data,fb_ary->arlen[imp_sth->rs_array_idx]);
- 					if ((CSFORM_IMPLIES_UTF8(fbh->csform)) && (fbh->ftype != SQLT_BIN)){
+ 					if ((CSFORM_IMPLIES_UTF8(imp_dbh, fbh->csform)) && (fbh->ftype != SQLT_BIN)){
 						SvUTF8_on(sv);
 					}
 				}
@@ -4271,7 +4290,7 @@ ora_parse_uid(imp_dbh_t *imp_dbh, char **uidp, char **pwdp)
 		return OCI_CRED_EXT;
 	}
 #ifdef ORA_OCI_112
-	if (!imp_dbh->using_drcp) {
+	if (0 == (imp_dbh->flags & ORA_IMP_DBH_USING_DRCP)) {
 #endif
 		OCIAttrSet_log_stat(imp_dbh, imp_dbh->seshp, OCI_HTYPE_SESSION,
 				*uidp, strlen(*uidp),
@@ -4293,9 +4312,7 @@ ora_db_reauthenticate(SV *dbh, imp_dbh_t *imp_dbh, char *uid, char *pwd)
 	dTHX;
 	sword status;
 #ifdef ORA_OCI_112
-	if (imp_dbh->using_drcp) {
-		return 0;
-	}
+	if (imp_dbh->flags & ORA_IMP_DBH_USING_DRCP) return 0;
 #endif
 	/* XXX should possibly create new session before ending the old so	*/
 	/* that if the new one can't be created, the old will still work.	*/
@@ -4411,6 +4428,7 @@ static int
 init_lob_refetch(SV *sth, imp_sth_t *imp_sth)
 {
 	dTHX;
+	D_imp_dbh_from_sth;
 	SV *sv;
 	SV *sql_select;
 	HV *lob_cols_hv = NULL;
@@ -4457,10 +4475,12 @@ init_lob_refetch(SV *sth, imp_sth_t *imp_sth)
 
 	if (status == OCI_SUCCESS) { /* There is a synonym, get the schema */
 		char *syn_schema=NULL;
-		char syn_name[100];
+		char *syn_name;
 		ub4  tn_len = 0, syn_schema_len = 0;
 
-		strncpy(syn_name,tablename,strlen(tablename));
+                Newx(syn_name, 1 + strlen(tablename), char);
+
+		strcpy(syn_name,tablename);
 		/* Put the synonym name here for later user */
 
 		OCIAttrGet_log_stat(imp_sth, imp_sth->dschp,  OCI_HTYPE_DESCRIBE,
@@ -4486,7 +4506,7 @@ init_lob_refetch(SV *sth, imp_sth_t *imp_sth)
                 "		lob refetch using a synonym named=%s for %s \n",
                 syn_name,tablename);
 
-
+                Safefree(syn_name);
 	}
 	OCIDescribeAny_log_stat(imp_sth, imp_sth->svchp, errhp, tablename, strlen(tablename),
 		(ub1)OCI_OTYPE_NAME, (ub1)1, (ub1)OCI_PTYPE_TABLE, imp_sth->dschp, status);
@@ -4558,7 +4578,7 @@ init_lob_refetch(SV *sth, imp_sth_t *imp_sth)
 		sv = newSViv(col_dbtype);
 		(void)sv_setpvn(sv, col_name, col_name_len);
 
-		if (CSFORM_IMPLIES_UTF8(SQLCS_IMPLICIT))
+		if (CSFORM_IMPLIES_UTF8(imp_dbh, SQLCS_IMPLICIT))
 			SvUTF8_on(sv);
 
 		(void)SvIOK_on(sv);	/* "what a wonderful hack!" */
@@ -4854,7 +4874,7 @@ post_execute_lobs(SV *sth, imp_sth_t *imp_sth, ub4 row_count)	/* XXX leaks handl
 					return oci_error(sth, errhp, status, "OCILobCharSetId");
 #endif /* OCI_ATTR_CHARSET_ID */
 		/* if data is utf8 but charset isn't then switch to utf8 csid */
-				csid = (SvUTF8(phs->sv) && !CS_IS_UTF8(csid)) ? utf8_csid : CSFORM_IMPLIED_CSID(csform);
+				csid = (SvUTF8(phs->sv) && !CS_IS_UTF8(csid)) ? utf8_csid : CSFORM_IMPLIED_CSID(imp_dbh, csform);
 				fbh->csid = csid;
 				fbh->csform = csform;
 			}

--- a/ocitrace.h
+++ b/ocitrace.h
@@ -321,12 +321,12 @@
 	OCIAttrGet_log_stat(imp_sth, stmhp, OCI_HTYPE_STMT,         \
 		(void*)(p1), (l), (a), imp_sth->errhp, stat)
 
-#define OCIAttrSet_log_stat(impxxh,th,ht,ah,s1,a,eh,stat)   \
+#define OCIAttrSet_log_stat(impxxh,th,ht,ah,s1,a,eh,stat)   do{\
 	stat=OCIAttrSet(th,ht,ah,s1,a,eh);				\
 	(DBD_OCI_TRACEON(impxxh)) ? PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
 		"%sAttrSet(%p,%s, %p,%lu,Attr=%s,%p)=%s\n",			\
 		OciTp, (void*)th,oci_hdtype_name(ht),(void *)ah,ul_t(s1),oci_attr_name(a),(void*)eh,	\
-		oci_status_name(stat)),stat : stat
+		oci_status_name(stat)),stat : stat; }while(0)
 
 #define OCIBindByName_log_stat(impsth,sh,bp,eh,p1,pl,v,vs,dt,in,al,rc,mx,cu,md,stat) \
 	stat=OCIBindByName(sh,bp,eh,p1,pl,v,vs,dt,in,al,rc,mx,cu,md);	\
@@ -369,17 +369,17 @@
 		(ub1)opt,(ub1)il,(ub1)ot,(void*)dh,				\
 		oci_status_name(stat)),stat : stat
 
-#define OCIDescriptorAlloc_ok(impxxh,envhp, p1, t)              \
+#define OCIDescriptorAlloc_ok(impxxh,envhp, p1, t)             do{ \
 	if (DBD_OCI_TRACEON(impxxh)) PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
 		"%sDescriptorAlloc(%p,%p,%s,0,0)\n",					\
 		OciTp,(void*)envhp,(void*)(p1),oci_hdtype_name(t));			\
 	if (OCIDescriptorAlloc((envhp), (void**)(p1), (t), 0, 0)==OCI_SUCCESS);	\
-	else croak("OCIDescriptorAlloc (type %d) failed",t)
+	else croak("OCIDescriptorAlloc (type %d) failed",t); }while(0)
 
-#define OCIDescriptorFree_log(impxxh,d,t)                       \
+#define OCIDescriptorFree_log(impxxh,d,t)                       do{\
 	if (DBD_OCI_TRACEON(impxxh)) PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
 		"%sDescriptorFree(%p,%s)\n", OciTp, (void*)d,oci_hdtype_name(t));	\
-	OCIDescriptorFree(d,t)
+	OCIDescriptorFree(d,t); }while(0)
 
 #define OCIEnvInit_log_stat(impdbh,ev,md,xm,um,stat)    \
 	stat=OCIEnvInit(ev,md,xm,um);					\
@@ -407,18 +407,18 @@
 	if (stat==OCI_SUCCESS) ;					\
 	else croak("OCIHandleAlloc(%s) failed",oci_hdtype_name(t))
 
-#define OCIHandleFree_log_stat(impxxh,hp,t,stat)    \
+#define OCIHandleFree_log_stat(impxxh,hp,t,stat)   do{ \
 	stat=OCIHandleFree(	(hp), (t));				\
-	(DBD_OCI_TRACEON(impxxh)) ? PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
+	if(DBD_OCI_TRACEON(impxxh)) PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
 		"%sHandleFree(%p,%s)=%s\n",OciTp,(void*)hp,oci_hdtype_name(t),		\
-		oci_status_name(stat)),stat : stat
+		oci_status_name(stat)); }while(0)
 
-#define OCILobGetLength_log_stat(impxxh,sh,eh,lh,l,stat)    \
+#define OCILobGetLength_log_stat(impxxh,sh,eh,lh,l,stat)  do{  \
 	stat=OCILobGetLength(sh,eh,lh,l);				\
 	(DBD_OCI_TRACEON(impxxh)) ? PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
 		"%sLobGetLength(%p,%p,%p,%p)=%s\n",				\
 		OciTp, (void*)sh,(void*)eh,(void*)lh,pul_t(l),		\
-		oci_status_name(stat)),stat : stat
+		oci_status_name(stat)),stat : stat; }while(0)
 
 
 #define OCILobGetChunkSize_log_stat(impdbh,sh,eh,lh,cs,stat)    \

--- a/t/16cached.t
+++ b/t/16cached.t
@@ -1,0 +1,30 @@
+#!perl
+#written by Andrey A Voropaev (avorop@mail.ru)
+
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+use FindBin qw($Bin);
+use lib 't/lib';
+use DBDOracleTestLib qw/ db_handle /;
+
+my $dbh;
+$| = 1;
+SKIP: {
+    $dbh = db_handle();
+
+    #  $dbh->{PrintError} = 1;
+    plan skip_all => 'Unable to connect to Oracle' unless $dbh;
+
+    note("Testing multiple cached connections...\n");
+
+    plan tests => 1;
+
+    system("perl -MExtUtils::testlib $Bin/cache2.pl");
+    ok($? == 0, "clean termination with multiple cached connections");
+}
+
+__END__
+

--- a/t/22cset.t
+++ b/t/22cset.t
@@ -1,0 +1,120 @@
+#!perl
+#written by Andrey A Voropaev (avorop@mail.ru)
+
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+use DBD::Oracle qw(ORA_OCI);
+use Encode;
+use lib 't/lib';
+use DBDOracleTestLib qw/ db_handle drop_table table force_drop_table /;
+
+my $dbh1;
+my $dbh2;
+$| = 1;
+SKIP: {
+    plan skip_all =>
+      'Unable to run multiple cset test, perl version is less than 5.6'
+      unless ( $] >= 5.006 );
+
+    $dbh1 = db_handle({
+        RaiseError => 0,
+        PrintError => 0,
+        AutoCommit => 1,
+        ora_charset => 'WE8MSWIN1252',
+    });
+
+    #  $dbh->{PrintError} = 1;
+    plan skip_all => 'Unable to connect to Oracle' unless $dbh1;
+
+    plan skip_all => 'Oracle charset tests unreliable for Oracle 8 client'
+      if ORA_OCI() < 9.0 and !$ENV{DBD_ALL_TESTS};
+
+    note("Testing multiple connections with different charsets...\n");
+
+    $dbh2 = db_handle({
+        RaiseError => 0,
+        PrintError => 0,
+        AutoCommit => 1,
+        ora_charset => 'AL32UTF8',
+    });
+
+    my $testcount = 3;
+
+    plan tests => $testcount;
+
+    my $tname = table();
+    force_drop_table($dbh1);
+    $dbh1->do(
+        qq{create table $tname (idx number, txt varchar2(50))}
+    );
+    die "Failed to create test table\n" if($dbh1->err);
+
+    my $sth = $dbh1->prepare(
+        qq{insert into $tname (idx, txt) values(?, ?)}
+    );
+    my $utf8_txt = 'äöüÜÖÄ';
+    my $x = $utf8_txt;
+    Encode::from_to($x, 'UTF-8', 'Latin1');
+    $sth->execute(1, $x);
+
+    $sth = $dbh1->prepare(
+        qq{select txt from $tname where idx=1}
+    );
+    $sth->execute();
+    my $r = $sth->fetchall_arrayref();
+    ok(must_be_latin1($r, $utf8_txt), "Latin1 support");
+
+    $sth = $dbh2->prepare(
+        qq{insert into $tname (idx, txt) values(?, ?)}
+    );
+    # insert bytes
+    $x = $utf8_txt;
+    $sth->execute(2, $x);
+    # insert characters
+    $x = $utf8_txt;
+    $sth->execute(3, Encode::decode('UTF-8', $x));
+
+    $sth = $dbh2->prepare(
+        qq{select txt from $tname where idx=?}
+    );
+    $sth->execute(2);
+    $r = $sth->fetchall_arrayref();
+    ok(must_be_utf8($r, $utf8_txt), "UTF-8 as bytes");
+    $sth->execute(3);
+    $r = $sth->fetchall_arrayref();
+    ok(must_be_utf8($r, $utf8_txt), "UTF-8 as characters");
+}
+
+sub must_be_latin1
+{
+    my $r = shift;
+    return unless @$r == 1;
+    my $x = $r->[0][0];
+    # it shouldn't be encoded
+    return if Encode::is_utf8($x);
+    Encode::from_to($x, 'Latin1', 'UTF-8');
+    return $x eq $_[0];
+}
+
+sub must_be_utf8
+{
+    my $r = shift;
+    return unless @$r == 1;
+    my $x = $r->[0][0];
+    # it should be encoded
+    return unless Encode::is_utf8($x);
+    return Encode::encode('UTF-8', $x) eq $_[0];
+}
+
+
+END {
+    eval {
+        drop_table($dbh1)
+    };
+}
+
+__END__
+

--- a/t/25plsql.t
+++ b/t/25plsql.t
@@ -331,7 +331,7 @@ SKIP: {
    # Also see http://www.mail-archive.com/dbi-users@perl.org/msg18835.html
 
    # Known bad OCI versions
-   my @bad_oci_vers = (9.2, 18.3, 18.5, 19.6, 19.9, 19.13, 21.4, 21.5);
+   my @bad_oci_vers = (9.2, 18.3, 18.5, 19.5, 19.6, 19.9, 19.13, 21.4, 21.5);
 
    skip 'Client version is known to have issue', 4
      if grep { $_ == DBD::Oracle::ORA_OCI() } @bad_oci_vers;

--- a/t/58object.t
+++ b/t/58object.t
@@ -13,7 +13,14 @@ use Test::More;
 
 $| = 1;
 
-$ENV{NLS_DATE_FORMAT} = 'YYYY-MM-DD"T"HH24:MI:SS';
+if($^O eq 'cygwin')
+{
+    DBD::Oracle::ora_cygwin_set_env('NLS_DATE_FORMAT', 'YYYY-MM-DD"T"HH24:MI:SS');
+}
+else
+{
+    $ENV{NLS_DATE_FORMAT} = 'YYYY-MM-DD"T"HH24:MI:SS';
+}
 
 # create a database handle
 my $dbh = eval{ db_handle( {

--- a/t/cache2.pl
+++ b/t/cache2.pl
@@ -1,0 +1,63 @@
+#!perl
+#written by Andrey A Voropaev (avorop@mail.ru)
+
+use strict;
+
+use DBI;
+
+tst1();
+tst2();
+tst1();
+tst2();
+
+sub tst1
+{
+    my $dbh = db_handle({
+            RaiseError => 0,
+            PrintError => 0,
+            AutoCommit => 1,
+            ora_charset => 'WE8MSWIN1252',
+        });
+    my $sth = $dbh->prepare(
+        q{ select 1 from dual }
+    );
+    $sth->execute();
+    my $r = $sth->fetchall_arrayref();
+}
+
+sub tst2
+{
+    my $dbh = db_handle({
+            RaiseError => 0,
+            PrintError => 0,
+            AutoCommit => 1,
+            ora_charset => 'AL32UTF8',
+        });
+    my $sth = $dbh->prepare(
+        q{ select 2 from dual }
+    );
+    $sth->execute();
+    my $r = $sth->fetchall_arrayref();
+}
+
+
+sub oracle_test_dsn {
+    my ( $default, $dsn ) = ( 'dbi:Oracle:', $ENV{ORACLE_DSN} );
+
+    $dsn ||= $ENV{DBI_DSN}
+      if $ENV{DBI_DSN} && ( $ENV{DBI_DSN} =~ m/^$default/io );
+    $dsn ||= $default;
+
+    return $dsn;
+}
+
+sub db_handle {
+
+    my $p = shift;
+    my $dsn    = oracle_test_dsn();
+    my $dbuser = $ENV{ORACLE_USERID} || 'scott/tiger';
+    my $dbh    = DBI->connect_cached( $dsn, $dbuser, '', $p );
+    return $dbh
+
+}
+


### PR DESCRIPTION
Patch fixes 2 problems:

 - Segfault at time of cleanup.
 - Problem with multiple charset in multiple connections to Oracle.

The rewrite is relatively large. I had to add refcounting to cached environments and removed use of global variables for storing information about charsets. Additionally there are few fixes that silence warnings (which really were small errors)

I've added 2 tests. One reproduces problem with Segfault, and another problem with different charsets.

Well, everything is relative. Tests work in CYGWIN. Also I didn't have chance to test DRCP and shared connections. Though, I suspect that support for shared connections is broken. At least it looks very suspicious.

It would be good, if someone tries to run it in other environments, since even copying of code could introduce some unexpected side-effects.

author: @avorop