### PR TITLE
Rewrite of login6

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -13,6 +13,7 @@ README.help.txt
 TESTING.md
 TODO
 cpanfile
+dbdcnx.c
 dbdimp.c
 dbdimp.h
 dbivport.h
@@ -63,7 +64,9 @@ t/10general.t
 t/12impdata.t
 t/14threads.t
 t/15nls.t
+t/15threads.t
 t/16cached.t
+t/16drcp.t
 t/20select.t
 t/21nchar.t
 t/22cset.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -874,7 +874,7 @@ if ($^O eq 'aix' and $osvers >= 4 and $Config{cc} ne 'xlc_r') {
     sleep 5;
 }
 
-if ($Config{archname} !~ /-thread\b/i) {
+if ($Config{archname} !~ /-threads?\b/i) {
     print "\n";
     print "WARNING: If you have problems you may need to rebuild perl with threading enabled.$BELL\n";
     sleep 5;
@@ -887,7 +887,7 @@ if ($Config{usemymalloc} eq 'y') {
 }
 
 print "WARNING: Your GNU C compiler is very old. Please upgrade.\n"
-    if ($Config{gccversion} and $Config{gccversion} =~ m/^(1|2\.[1-5])/);
+    if ($Config{gccversion} and $Config{gccversion} =~ m/^(1\.|2\.[1-5])/);
 
 if ($opts{LINKTYPE} && $opts{LINKTYPE} eq 'static') {
     print "** Note: DBD::Oracle will be built *into* a NEW perl binary. You MUST use that new perl.\n";
@@ -1789,8 +1789,8 @@ sub symbol_search {
 
         eval { # This chunk is for Oracle::OCI
             require Data::Dumper;
-            print main::MK_PM Data::Dumper->Purity(1)->Terse(0)->Indent(1)->Useqq(1)
-                ->Dump([\%opts, $self], [qw(dbd_oracle_mm_opts dbd_oracle_mm_self)]);
+            my $dmp = Data::Dumper->new([\%opts, $self], [qw(dbd_oracle_mm_opts dbd_oracle_mm_self)]);
+            print main::MK_PM $dmp->Purity(1)->Terse(0)->Indent(1)->Useqq(1)->Dump;
         };
         if ($@) {
             warn "Can't dump config to mk.pm so you won't be able to build Oracle::OCI later if you wanted to: $@\n";

--- a/Oracle.h
+++ b/Oracle.h
@@ -26,7 +26,7 @@
 #endif
 
 /* egcs-1.1.2 does not have _int64 */
-#if defined(__MINGW32__) || defined(__CYGWIN32__)
+#if defined(__MINGW32__) || defined(__CYGWIN32__) || defined(__CYGWIN__)
 #define _int64 long long
 #endif
 
@@ -61,6 +61,8 @@
 void	dbd_init _((dbistate_t *dbistate));
 void	dbd_init_oci_drh _((imp_drh_t * imp_drh));
 void	dbd_dr_destroy _((SV *drh, imp_drh_t *imp_drh));
+void	dbd_dr_globals_init _(());
+void	dbd_dr_mng _(());
 
 int	 dbd_db_login  _((SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *user, char *pwd));
 int	 dbd_db_do _((SV *sv, char *statement));

--- a/Oracle.h
+++ b/Oracle.h
@@ -118,6 +118,13 @@ ub4	 ora_blob_read_mb_piece _((SV *sth, imp_sth_t *imp_sth, imp_fbh_t *fbh, SV *
 #define ORA_XMLTYPE			108
 
 
+/* define some constants from newer OCI versions */
+#ifndef OCI_SPOOL_ATTRVAL_TIMEDWAIT
+#define OCI_SPOOL_ATTRVAL_TIMEDWAIT 3
+#endif
+#ifndef OCI_SPOOL_ATTRVAL_NOWAIT
+#define OCI_SPOOL_ATTRVAL_NOWAIT 1
+#endif
 
 
 /* other Oracle not in noraml API defines

--- a/dbdcnx.c
+++ b/dbdcnx.c
@@ -1,0 +1,1120 @@
+/* notes {{{
+ * This module attempts to provide reuse of OCIEnv
+ * and storage for session pool(s).
+ *
+ * Note, configuration uses acronym "drcp", which is
+ * somewhat misleading. DRCP stands for "connection pooling"
+ * and DBD::Oracle offers "session pooling", which is
+ * not "connection pooling" (that is also offered by Oracle).
+ *
+ * To make things complex DBD::Oracle offers 2 ways to
+ * share connections between threads. Such sharing
+ * requires that one thread does not use pointers
+ * to data allocated in another thread. In perl,
+ * each thread gets copy of perl interpreter, and each
+ * thread has its own heap for memory allocation.
+ * When the thread ends, that memory may get released,
+ * which leads to problems if the memory is referenced
+ * from another thread.
+ *
+ * It appears, that OCI uses itsown memory pool for
+ * allocation, so the data allocated in one thread
+ * is still accessible in another thread. At least
+ * tests don't fail in such cases. There are
+ * also OCI internal mutexes that protect access to
+ * that memory. The good news, one may ask OCI to allocate
+ * some memory for the caller. That is what this
+ * module is using.
+ *
+ * When OCIEnv is created, it uses 3 parameters
+ * that define the functionality of new OCIEnv.
+ * Those are: mode, charset and ncharset. So, when
+ * we need some OCIEnv we have to check for existing
+ * ones that have matching parameters. If charset
+ * or ncharset is 0, then current value from environment
+ * is used (OCINlsEnvironmentVariableGet)
+ *
+ * The session pool is identified (in addition to
+ * charsets and mode for OCIEnv) by dbname, user
+ * and "rlb" (activity of load-balancer). Since all
+ * sessions are "homogenous", Oracle won't check
+ * password when new session is requested. So probably
+ * it makes sense to check it here. So password
+ * is also saved.
+ *
+ * This module does not use HV to find cached
+ * handles because HV may need to allocate memory
+ * from current thread, and that is not good. Still
+ * it is very unlikely that someone uses thousands
+ * of different pools/characters, so simple
+ * running through doubly-linked list should be
+ * fast enough (and maybe even faster) than hashing.
+ *
+ * Now, how long shall be cached all handles? As long
+ * as there are users. Each open connection is a user.
+ * Additionally every "driver"-object is a user.
+ * The drivier-object is allocated in each thread
+ * that tries to connect to DB and is released when
+ * thread ends.
+ }}} */
+#include "Oracle.h"
+DBISTATE_DECLARE;
+
+typedef struct llist_t llist_t;
+/* small implementation for doubly-linked list {{{ */
+struct llist_t{
+    llist_t * left;
+    llist_t * right;
+};
+
+PERL_STATIC_INLINE int
+llist_empty(const llist_t * list)
+{
+    return list->left == list;
+}
+
+PERL_STATIC_INLINE void
+llist_init(llist_t *list)
+{
+    list->right = list->left = list;
+}
+
+PERL_STATIC_INLINE void
+llist_add(llist_t * left, llist_t * right)
+{
+    llist_t * old;
+
+    // first save the pointer from the left->rigth
+    old = left->right;
+
+    // now left->right shall point to right
+    left->right = right;
+
+    // now the old left pointer shall point to what the
+    // new right->left was pointing
+    old->left = right->left;
+
+    // now right->left shall contain the left
+    right->left = left;
+
+    // finally
+    old->left->right = old;
+}
+
+PERL_STATIC_INLINE void
+llist_drop(llist_t * el)
+{
+    if(llist_empty(el)) return;
+    el->left->right = el->right;
+    el->right->left = el->left;
+    llist_init(el);
+}
+
+// this is pointer to the left element in chain
+PERL_STATIC_INLINE llist_t *
+llist_left(const llist_t * list)
+{
+    return list->left;
+}
+
+// this one is a pointer to the right element in chain
+PERL_STATIC_INLINE llist_t *
+llist_right(const llist_t *list)
+{
+    return list->right;
+}
+/* }}} */
+
+#if defined(USE_ITHREADS)
+static perl_mutex mng_lock;
+#endif
+static llist_t mng_list;
+static int dr_instances;
+/* to get information about charsets we need these */
+static OCIEnv * mng_env;
+static OCIError * mng_err;
+
+/*dbd_dr_globals_init{{{*/
+void
+dbd_dr_globals_init()
+{
+#if defined(USE_ITHREADS)
+    dTHX;
+    MUTEX_INIT(&mng_lock);
+#endif
+    llist_init(&mng_list);
+    dr_instances = 0;
+    mng_env = NULL;
+    mng_err = NULL;
+}
+/*}}}*/
+
+struct box_st{
+    llist_t lock;
+    int refs; /* this shall be positiv for OCIEnv and negativ for Session Pool */
+};
+
+struct env_box_st
+{
+    box_t base;
+    OCIEnv * envhp;
+    ub4 mode;
+    ub2 cset;
+    ub2 ncset;
+};
+typedef struct env_box_st env_box_t;
+
+#ifdef ORA_OCI_112
+struct pool_box_st{
+    box_t base;
+    env_box_t * env;
+    OCISPool *poolhp;
+    OCIError *errhp;
+    OraText *name;
+    ub4	name_len;
+    ub2 pass_len;
+    ub2 dbname_len;
+    /* all text strings are stored below. The buffer
+     * is long enough to contain dbname_len+user_len+pass_len + 4 bytes.
+     * So pass is box->buf + 1;
+     * dbname is box->buf + 2 + box->pass_len
+     * user is box->buf + 3 + box->dbname_len + box->pass_len
+     * First byte is 0 if RLB is not desired.
+     */
+    char buf[1];
+};
+typedef struct pool_box_st pool_box_t;
+#endif
+
+#define tracer(imp, dlvl, vlvl, ...) if \
+    (DBIc_DBISTATE(imp)->debug >= (dlvl) || dbd_verbose >= (vlvl) )\
+            PerlIO_printf(DBIc_LOGPIO(imp), __VA_ARGS__)
+
+/* local_error{{{*/
+static int
+local_error(pTHX_ SV * h, const char * fmt, ...)
+{
+    va_list ap;
+    SV * txt_sv = sv_newmortal();
+    SV * code_sv = get_sv("DBI::stderr", 0);
+    D_imp_xxh(h);
+    if(code_sv == NULL)
+    {
+        code_sv  = sv_newmortal();
+        sv_setiv(code_sv, 2000000000);
+    }
+    va_start(ap, fmt);
+    sv_vsetpvf(txt_sv, fmt, &ap);
+    va_end(ap);
+    DBIh_SET_ERR_SV(h, imp_xxh, code_sv, txt_sv, &PL_sv_undef, &PL_sv_undef);
+    return FALSE;
+}
+/*}}}*/
+/* release_env{{{*/
+static void
+release_env(pTHX_ env_box_t * box)
+{
+    llist_drop(&box->base.lock);
+    if(dbd_verbose >= 3)
+        warn("Releasing OCIEnv %p\n", box->envhp);
+    (void)OCIHandleFree(box->envhp, OCI_HTYPE_ENV);
+}/*}}}*/
+
+/* new_envhp_box{{{*/
+static int
+new_envhp_box(pTHX_ env_box_t ** slot, dblogin_info_t * ctrl)
+{
+    imp_dbh_t * imp_dbh = ctrl->imp_dbh;
+    env_box_t * box;
+    OCIEnv * envhp;
+    sword status = OCIEnvNlsCreate(
+            &envhp, ctrl->mode,
+            0, NULL, NULL, NULL,
+            sizeof(*box), (dvoid**)&box,
+            imp_dbh->cset, imp_dbh->ncset
+    );
+    if (status != OCI_SUCCESS)
+        return local_error(aTHX_ ctrl->dbh, "Failed to allocate OCIEnv");
+    tracer(imp_dbh, 3, 3, "allocated new OCIEnv %p (cset %d, ncset %d, mode %d)\n",
+            envhp, (int)imp_dbh->cset, (int)imp_dbh->ncset, (int)ctrl->mode);
+    llist_init(&box->base.lock);
+    box->envhp = envhp;
+    box->base.refs = dr_instances;
+    box->cset = imp_dbh->cset;
+    box->ncset = imp_dbh->ncset;
+    box->mode = ctrl->mode;
+    llist_add(&mng_list, &box->base.lock);
+    *slot = box;
+    return TRUE;
+}/*}}}*/
+/* figure_out_charsets {{{*/
+static int
+figure_out_charsets(pTHX_ dblogin_info_t * ctrl)
+{
+    imp_dbh_t * imp_dbh = ctrl->imp_dbh;
+    if(ctrl->cset != NULL)
+    {
+        imp_dbh->cset = OCINlsCharSetNameToId(
+                mng_env, (OraText*)ctrl->cset
+        );
+        if(imp_dbh->cset == 0) return local_error(
+                aTHX_ ctrl->dbh, "Invalid ora_charset '%s'", ctrl->cset
+        );
+    }
+    else if(imp_dbh->cset == 0)
+    {
+        size_t rsize;
+        sword status = OCINlsEnvironmentVariableGet(
+            &imp_dbh->cset, 0, OCI_NLS_CHARSET_ID, 0, &rsize
+        );
+        if(status != OCI_SUCCESS || imp_dbh->cset == 0)
+            return local_error(aTHX_ ctrl->dbh, "NLS_LANG appears to be invalid");
+    }
+    if(ctrl->ncset != NULL)
+    {
+        imp_dbh->ncset = OCINlsCharSetNameToId(
+                mng_env, (OraText*)ctrl->ncset
+        );
+        if(imp_dbh->ncset == 0) return local_error(
+                aTHX_ ctrl->dbh, "Invalid ora_ncharset '%s'", ctrl->ncset
+        );
+    }
+    else if(imp_dbh->ncset == 0)
+    {
+        size_t rsize;
+        sword status = OCINlsEnvironmentVariableGet(
+            &imp_dbh->ncset, 0, OCI_NLS_NCHARSET_ID, 0, &rsize
+        );
+        if(status != OCI_SUCCESS || imp_dbh->ncset == 0)
+            return local_error(aTHX_ ctrl->dbh, "NLS_NCHAR appears to be invalid");
+    }
+
+    return TRUE;
+}/*}}}*/
+/*find_env{{{*/
+static env_box_t *
+find_env(ub4 mode, ub2 cset, ub2 ncset)
+{
+    llist_t * base = llist_left(&mng_list);
+    while(base != &mng_list)
+    {
+        env_box_t * box = (env_box_t *)base;
+        if(box->base.refs > 0
+                && box->mode == mode
+                && box->ncset == ncset
+                && box->cset == cset
+          )
+        {
+            /* check if this handle is still valid */
+            if(box->base.refs == dr_instances)
+            {
+                OCIError 	*errhp;
+                sword status=OCIHandleAlloc(
+                        box->envhp,
+                        (dvoid**)&errhp,
+                        OCI_HTYPE_ERROR, 0, NULL
+                );
+                if(status != OCI_SUCCESS)
+                {
+                    llist_drop(base);
+                    OCIHandleFree(box->envhp, OCI_HTYPE_ENV);
+                    return NULL;
+                }
+            }
+            return box;
+        }
+        base = llist_left(base);
+    }
+    return NULL;
+}
+/*}}}*/
+/* simple_connect {{{*/
+static int
+simple_connect(pTHX_ dblogin_info_t * ctrl)
+{
+    imp_dbh_t * imp_dbh = ctrl->imp_dbh;
+    sword status;
+    ub4 ulen, plen, ctype;
+
+    tracer(imp_dbh, 3, 3, "using OCIEnv %p to connect\n", imp_dbh->envhp);
+
+    OCIHandleAlloc_ok(
+            imp_dbh, imp_dbh->envhp, &imp_dbh->errhp,
+            OCI_HTYPE_ERROR, status
+    );
+    if(status != OCI_SUCCESS)
+        return local_error(aTHX_ ctrl->dbh, "Failed to allocate OCIError\n");
+
+    OCIHandleAlloc_ok(
+            imp_dbh, imp_dbh->envhp, &imp_dbh->srvhp,
+            OCI_HTYPE_SERVER, status
+    );
+    if(status != OCI_SUCCESS)
+        return local_error(aTHX_ ctrl->dbh, "Failed to allocate OCIServer\n");
+
+    OCIHandleAlloc_ok(
+            imp_dbh, imp_dbh->envhp, &imp_dbh->svchp,
+            OCI_HTYPE_SVCCTX, status
+    );
+    if(status != OCI_SUCCESS)
+        return local_error(aTHX_ ctrl->dbh, "Failed to allocate OCISvcCtx\n");
+
+    OCIHandleAlloc_ok(
+            imp_dbh, imp_dbh->envhp, &imp_dbh->seshp,
+            OCI_HTYPE_SESSION, status
+    );
+    if(status != OCI_SUCCESS)
+        return local_error(aTHX_ ctrl->dbh, "Failed to allocate OCISession\n");
+
+    OCIServerAttach_log_stat(imp_dbh, ctrl->dbname,OCI_DEFAULT, status);
+    if (status != OCI_SUCCESS)
+            return oci_error(ctrl->dbh, imp_dbh->errhp, status, "OCIServerAttach");
+
+    OCIAttrSet_log_stat(
+            imp_dbh, imp_dbh->svchp,
+            OCI_HTYPE_SVCCTX,
+            imp_dbh->srvhp,
+            (ub4) 0, OCI_ATTR_SERVER, imp_dbh->errhp, status
+    );
+    if (status != OCI_SUCCESS) return oci_error(
+            ctrl->dbh, imp_dbh->errhp, status, "OCIAttrSet OCI_HTYPE_SVCCTX"
+    );
+    plen = (ub4)strlen(ctrl->pwd);
+    ulen = (ub4)strlen(ctrl->uid);
+    if(plen == 0 && ulen == 0) ctype = OCI_CRED_EXT;
+    else
+    {
+        ctype = OCI_CRED_RDBMS;
+        OCIAttrSet_log_stat(
+                imp_dbh, imp_dbh->seshp,
+                OCI_HTYPE_SESSION,
+                ctrl->uid, ulen,
+                (ub4) OCI_ATTR_USERNAME,
+                imp_dbh->errhp, status
+        );
+        if (status != OCI_SUCCESS) return oci_error(
+                ctrl->dbh, imp_dbh->errhp, status, "OCIAttrSet OCI_ATTR_USERNAME"
+        );
+
+        OCIAttrSet_log_stat(
+                imp_dbh, imp_dbh->seshp,
+                OCI_HTYPE_SESSION,
+                ((plen) ? ctrl->pwd : NULL), plen,
+                (ub4) OCI_ATTR_PASSWORD,
+                imp_dbh->errhp, status
+        );
+        if (status != OCI_SUCCESS) return oci_error(
+                ctrl->dbh, imp_dbh->errhp, status, "OCIAttrSet OCI_ATTR_PASSWORD"
+        );
+    }
+#ifdef ORA_OCI_112
+    if(ctrl->driver_name_len != 0)
+    {
+        OCIAttrSet_log_stat(
+            imp_dbh, imp_dbh->seshp, OCI_HTYPE_SESSION,
+            ctrl->driver_name, ctrl->driver_name_len,
+            OCI_ATTR_DRIVER_NAME,
+            imp_dbh->errhp, status
+        );
+        if (status != OCI_SUCCESS) return oci_error(
+                ctrl->dbh, imp_dbh->errhp, status, "OCIAttrSet OCI_ATTR_DRIVER_NAME"
+        );
+    }
+#endif
+
+    OCISessionBegin_log_stat(
+            imp_dbh, imp_dbh->svchp, imp_dbh->errhp, imp_dbh->seshp,
+            ctype, ctrl->session_mode, status
+    );
+    if (status == OCI_SUCCESS_WITH_INFO)
+    {
+        /* eg ORA-28011: the account will expire soon; change your password now */
+        oci_error(ctrl->dbh, imp_dbh->errhp, status, "OCISessionBegin");
+        status = OCI_SUCCESS;
+    }
+    if (status != OCI_SUCCESS)
+        return oci_error(ctrl->dbh, imp_dbh->errhp, status, "OCISessionBegin");
+
+    OCIAttrSet_log_stat(
+            imp_dbh, imp_dbh->svchp,
+            (ub4) OCI_HTYPE_SVCCTX,
+            imp_dbh->seshp, (ub4) 0,
+            (ub4) OCI_ATTR_SESSION,
+            imp_dbh->errhp, status
+    );
+    if (status != OCI_SUCCESS) return oci_error(
+            ctrl->dbh, imp_dbh->errhp, status, "OCIAttrSet OCI_ATTR_SESSION"
+    );
+    return TRUE;
+}/*}}}*/
+#ifdef ORA_OCI_112
+/*release_pool{{{*/
+static void
+release_pool(pTHX_ pool_box_t * box)
+{
+    env_box_t * ebox;
+    if(dbd_verbose >= 3)
+        warn("Releasing pool %p\n", box->poolhp);
+
+    ebox = box->env;
+    llist_drop(&box->base.lock);
+    (void)OCISessionPoolDestroy (box->poolhp, box->errhp, OCI_DEFAULT);
+    (void)OCIHandleFree(box->poolhp, OCI_HTYPE_SPOOL);
+    ebox->base.refs--;
+    if(ebox->base.refs == 0) release_env(aTHX_ ebox);
+}/*}}}*/
+/*cnx_pool_min{{{*/
+void
+cnx_pool_min(pTHX_ SV * dbh, imp_dbh_t * imp_dbh, ub4 val)
+{
+    pool_box_t * box;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrSet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&val, sizeof(val),
+            OCI_ATTR_SPOOL_MIN, box->errhp
+    );
+    if(status != OCI_SUCCESS)
+        (void)oci_error(dbh, box->errhp, status, "OCIAttrSet POOL_MIN");
+}/*}}}*/
+/*cnx_pool_max{{{*/
+void
+cnx_pool_max(pTHX_ SV * dbh, imp_dbh_t * imp_dbh, ub4 val)
+{
+    pool_box_t * box;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrSet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&val, sizeof(val),
+            OCI_ATTR_SPOOL_MAX, box->errhp
+    );
+    if(status != OCI_SUCCESS)
+        (void)oci_error(dbh, box->errhp, status, "OCIAttrSet POOL_MAX");
+}/*}}}*/
+/*cnx_pool_incr{{{*/
+void
+cnx_pool_incr(pTHX_ SV * dbh, imp_dbh_t * imp_dbh, ub4 val)
+{
+    pool_box_t * box;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrSet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&val, sizeof(val),
+            OCI_ATTR_SPOOL_INCR, box->errhp
+    );
+    if(status != OCI_SUCCESS)
+        (void)oci_error(dbh, box->errhp, status, "OCIAttrSet POOL_INCR");
+}/*}}}*/
+/*cnx_pool_mode{{{*/
+void
+cnx_pool_mode(pTHX_ SV * dbh, imp_dbh_t * imp_dbh, ub4 val)
+{
+    pool_box_t * box;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrSet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&val, sizeof(val),
+            OCI_ATTR_SPOOL_GETMODE, box->errhp
+    );
+    if(status != OCI_SUCCESS)
+        (void)oci_error(dbh, box->errhp, status, "OCIAttrSet POOL_GETMODE");
+}/*}}}*/
+/*cnx_pool_wait{{{*/
+void
+cnx_pool_wait(pTHX_ SV * dbh, imp_dbh_t * imp_dbh, ub4 val)
+{
+    pool_box_t * box;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrSet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&val, sizeof(val),
+            OCI_ATTR_SPOOL_WAIT_TIMEOUT, box->errhp
+    );
+    if(status != OCI_SUCCESS)
+        (void)oci_error(dbh, box->errhp, status, "OCIAttrSet POOL_WAIT_TIMEOUT");
+}/*}}}*/
+/*cnx_is_pooled_session{{{*/
+int
+cnx_is_pooled_session(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
+{
+    return (imp_dbh->lock->refs < 0);
+}/*}}}*/
+/*cnx_get_pool_mode{{{*/
+int
+cnx_get_pool_mode(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
+{
+    pool_box_t * box;
+    ub4 v, l;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return 0;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrGet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&v, &l,
+            OCI_ATTR_SPOOL_GETMODE, box->errhp
+    );
+    if(status == OCI_SUCCESS) return (int)v;
+    (void)oci_error(dbh, box->errhp, status, "OCIAttrGet POOL_METHOD");
+    return 0;
+}/*}}}*/
+/*cnx_get_pool_wait{{{*/
+int
+cnx_get_pool_wait(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
+{
+    pool_box_t * box;
+    ub4 v, l;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return 0;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrGet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&v, &l,
+            OCI_ATTR_SPOOL_WAIT_TIMEOUT, box->errhp
+    );
+    if(status == OCI_SUCCESS) return (int)v;
+    (void)oci_error(dbh, box->errhp, status, "OCIAttrGet POOL_WAIT_TIMEOUT");
+    return 0;
+}/*}}}*/
+/*cnx_get_pool_used{{{*/
+int
+cnx_get_pool_used(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
+{
+    pool_box_t * box;
+    ub4 v, l;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return 0;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrGet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&v, &l,
+            OCI_ATTR_SPOOL_BUSY_COUNT, box->errhp
+    );
+    if(status == OCI_SUCCESS) return (int)v;
+    (void)oci_error(dbh, box->errhp, status, "OCIAttrGet POOL_USED");
+    return 0;
+}/*}}}*/
+/*cnx_get_pool_max{{{*/
+int
+cnx_get_pool_max(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
+{
+    pool_box_t * box;
+    ub4 v, l;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return 0;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrGet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&v, &l,
+            OCI_ATTR_SPOOL_MAX, box->errhp
+    );
+    if(status == OCI_SUCCESS) return (int)v;
+    (void)oci_error(dbh, box->errhp, status, "OCIAttrGet POOL_MAX");
+    return 0;
+}/*}}}*/
+/*cnx_get_pool_min{{{*/
+int
+cnx_get_pool_min(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
+{
+    pool_box_t * box;
+    ub4 v, l;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return 0;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrGet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&v, &l,
+            OCI_ATTR_SPOOL_MIN, box->errhp
+    );
+    if(status == OCI_SUCCESS) return (int)v;
+    (void)oci_error(dbh, box->errhp, status, "OCIAttrGet POOL_MIN");
+    return 0;
+}/*}}}*/
+/*cnx_get_pool_incr{{{*/
+int
+cnx_get_pool_incr(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
+{
+    pool_box_t * box;
+    ub4 v, l;
+    sword status;
+    if(imp_dbh->lock->refs > 0) return 0;
+    box = ((pool_box_t*)imp_dbh->lock);
+    status = OCIAttrGet(
+            box->poolhp, OCI_HTYPE_SPOOL,
+            (dvoid*)&v, &l,
+            OCI_ATTR_SPOOL_INCR, box->errhp
+    );
+    if(status == OCI_SUCCESS) return (int)v;
+    (void)oci_error(dbh, box->errhp, status, "OCIAttrGet POOL_INCR");
+    return 0;
+}/*}}}*/
+/*cnx_get_pool_rlb{{{*/
+int
+cnx_get_pool_rlb(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
+{
+    if(imp_dbh->lock->refs > 0) return 0;
+    return (int)(((pool_box_t*)imp_dbh->lock)->buf[0]);
+}/*}}}*/
+/*find_pool{{{*/
+static pool_box_t *
+find_pool(dblogin_info_t * ctrl)
+{
+    imp_dbh_t * imp_dbh = ctrl->imp_dbh;
+    llist_t * base = llist_left(&mng_list);
+    while(base != &mng_list)
+    {
+        char * name;
+        pool_box_t * box = (pool_box_t *)base;
+        base = llist_left(base);
+        if(box->base.refs > 0) continue;
+        if(box->env->mode != ctrl->mode) continue;
+        if(box->env->ncset != imp_dbh->ncset) continue;
+        if(box->env->cset != imp_dbh->cset) continue;
+        name = box->buf + 2 + box->pass_len;
+        if(0 != strcmp(name, ctrl->dbname)) continue;
+        name += box->dbname_len + 1;
+        if(0 != strcmp(name, ctrl->uid)) continue;
+        if((int)(box->buf[0]) != (int)(ctrl->pool_rlb)) continue;
+        return box;
+    }
+    return NULL;
+}
+/*}}}*/
+/* new_pool_box{{{*/
+int
+new_pool_box(pTHX_ pool_box_t ** slot, dblogin_info_t * ctrl)
+{
+    imp_dbh_t * imp_dbh = ctrl->imp_dbh;
+    OCIEnv * envhp = imp_dbh->envhp;
+    pool_box_t * box;
+    char * name;
+    OCISPool *poolhp;
+    ub4 mode;
+    ub4 dbname_len = strlen(ctrl->dbname);
+    ub4 user_len = strlen(ctrl->uid);
+    ub4 pwd_len = strlen(ctrl->pwd);
+    size_t boxlen = sizeof(*box) + dbname_len + user_len + pwd_len + 3;
+
+    sword status = OCIHandleAlloc(
+            envhp, (dvoid*)&poolhp, OCI_HTYPE_SPOOL, boxlen, (dvoid**)&box
+    );
+    if (status != OCI_SUCCESS)
+        return local_error(aTHX_ ctrl->dbh, "Failed to allocate OCISPool");
+
+    status = OCIHandleAlloc(envhp, (dvoid*)&box->errhp, OCI_HTYPE_ERROR, 0, NULL);
+    if (status != OCI_SUCCESS)
+    {
+        OCIHandleFree(poolhp, OCI_HTYPE_SPOOL);
+        return local_error(aTHX_ ctrl->dbh, "Failed to allocate OCIError");
+    }
+#ifdef ORA_OCI_112
+    if(ctrl->driver_name_len != 0)
+    {
+        OCIAuthInfo * authp;
+        status = OCIHandleAlloc(envhp, (dvoid*)&authp, OCI_HTYPE_AUTHINFO, 0, NULL);
+        if(status != OCI_SUCCESS)
+        {
+            OCIHandleFree(box->errhp, OCI_HTYPE_ERROR);
+            OCIHandleFree(poolhp, OCI_HTYPE_SPOOL);
+            return local_error(aTHX_ ctrl->dbh, "Failed to allocate OCIAuthInfo");
+        }
+        status = OCIAttrSet(
+            authp, OCI_HTYPE_AUTHINFO,
+            (OraText*)ctrl->driver_name, ctrl->driver_name_len,
+            OCI_ATTR_DRIVER_NAME,
+            box->errhp
+        );
+        if(status != OCI_SUCCESS)
+        {
+            (void)oci_error(ctrl->dbh, box->errhp, status, "OCIAttrSet DriverName");
+            OCIHandleFree(box->errhp, OCI_HTYPE_ERROR);
+            OCIHandleFree(authp, OCI_HTYPE_AUTHINFO);
+            OCIHandleFree(poolhp, OCI_HTYPE_SPOOL);
+            return FALSE;
+        }
+        status = OCIAttrSet(
+            poolhp, OCI_HTYPE_SPOOL,
+            authp, 0,
+            OCI_ATTR_SPOOL_AUTH,
+            box->errhp
+        );
+        if(status != OCI_SUCCESS)
+        {
+            (void)oci_error(ctrl->dbh, box->errhp, status, "OCIAttrSet OCIAuthInfo");
+            OCIHandleFree(box->errhp, OCI_HTYPE_ERROR);
+            OCIHandleFree(authp, OCI_HTYPE_AUTHINFO);
+            OCIHandleFree(poolhp, OCI_HTYPE_SPOOL);
+            return FALSE;
+        }
+    }
+#endif
+
+
+    mode = OCI_SPC_HOMOGENEOUS;
+    if(!ctrl->pool_rlb) mode |= OCI_SPC_NO_RLB;
+    status = OCISessionPoolCreate(
+            envhp,
+            box->errhp,
+            poolhp,
+            &box->name,
+            &box->name_len,
+            (OraText *) ctrl->dbname,
+            dbname_len,
+            ctrl->pool_min,
+            ctrl->pool_max,
+            ctrl->pool_incr,
+            (OraText *) ctrl->uid,
+            user_len,
+            (OraText *) ctrl->pwd,
+            pwd_len,
+            mode
+    );
+    if (status != OCI_SUCCESS)
+    {
+        (void)oci_error(ctrl->dbh, box->errhp, status, "OCISessionPoolCreate");
+        OCIHandleFree(box->errhp, OCI_HTYPE_ERROR);
+        OCIHandleFree(poolhp, OCI_HTYPE_SPOOL);
+        return FALSE;
+    }
+    llist_init(&box->base.lock);
+    box->env = (env_box_t *)imp_dbh->lock;
+    box->buf[0] = ctrl->pool_rlb;
+    name = box->buf + 1;
+    strcpy(name, ctrl->pwd);
+    box->pass_len = pwd_len;
+    name += pwd_len + 1;
+    strcpy(name, ctrl->dbname);
+    box->dbname_len = dbname_len;
+    name += dbname_len + 1;
+    strcpy(name, ctrl->uid);
+
+    box->base.refs = -dr_instances;
+    llist_add(&mng_list, &box->base.lock);
+    box->poolhp = poolhp;
+
+    *slot = box;
+    return TRUE;
+}/*}}}*/
+/* session_from_pool {{{*/
+static int
+session_from_pool(pTHX_ dblogin_info_t * ctrl)
+{
+    imp_dbh_t * imp_dbh = ctrl->imp_dbh;
+    sword status;
+    OCIAuthInfo *authp;
+    OraText *rettag;
+    OraText *tag;
+    ub4 rettagl;
+    STRLEN tagl;
+    boolean session_tag_found;
+    /* try to find existing pool */
+    pool_box_t * box = find_pool(ctrl);
+    if(box != NULL)
+    {
+        if(0 != strcmp(box->buf + 1, ctrl->pwd))
+            return local_error(aTHX_ ctrl->dbh, "Password for session is wrong");
+    }
+    else if(!new_pool_box(aTHX_ &box, ctrl)) return FALSE;
+
+    /* replace env-box with pool-box. It shall be cleared by DESTROY */
+    imp_dbh->lock = &box->base;
+    box->base.refs--; /* refcount for pool is negative! I know, I know... */
+
+    OCIHandleAlloc_ok(
+        imp_dbh, imp_dbh->envhp, &imp_dbh->errhp, OCI_HTYPE_ERROR,  status
+    );
+    if(status != OCI_SUCCESS)
+        return local_error(aTHX_ ctrl->dbh, "OCIError alloc failed");
+
+    OCIHandleAlloc_ok(
+        imp_dbh, imp_dbh->envhp, &authp, OCI_HTYPE_AUTHINFO, status
+    );
+    if(status != OCI_SUCCESS)
+        return local_error(aTHX_ ctrl->dbh, "OCIAuthInfo alloc failed");
+    if(ctrl->pool_class != NULL)
+    {
+        tag = (OraText*)SvPV(ctrl->pool_class, tagl);
+        OCIAttrSet_log_stat(
+                imp_dbh, authp,
+                OCI_HTYPE_AUTHINFO,
+                tag, (ub4) tagl,
+                OCI_ATTR_CONNECTION_CLASS, imp_dbh->errhp, status
+        );
+        if(status != OCI_SUCCESS) return local_error(aTHX_ ctrl->dbh,
+                "OCIAuthInfo setting connection class failed");
+    }
+
+    tag = NULL;
+    tagl = 0;
+    if(ctrl->pool_tag != NULL)
+    {
+        tag = (OraText*)SvPV(ctrl->pool_tag, tagl);
+        if(tagl == 0) tag = NULL;
+    }
+
+    OCISessionGet_log_stat(
+            imp_dbh, imp_dbh->envhp,
+            imp_dbh->errhp,
+            &imp_dbh->svchp,
+            authp,
+            box->name, box->name_len,
+            tag, (ub4)tagl,
+            &rettag, &rettagl, &session_tag_found,
+            status
+    );
+    if (status != OCI_SUCCESS)
+    {
+        (void)oci_error(ctrl->dbh, imp_dbh->errhp, status, "OCISessionGet");
+        OCIHandleFree_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO, status);
+        return FALSE;
+    }
+    if(session_tag_found && rettagl != 0)
+    {
+        if(imp_dbh->session_tag != NULL) SvREFCNT_dec(imp_dbh->session_tag);
+        imp_dbh->session_tag = newSVpv((char*)rettag, rettagl);
+    }
+
+    OCIHandleFree_log_stat(imp_dbh, authp, OCI_HTYPE_AUTHINFO, status);
+
+    /* Get server and session handles from service context handle,
+     * allocated by OCISessionGet. */
+    OCIAttrGet_log_stat(
+            imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, &imp_dbh->srvhp, NULL,
+            OCI_ATTR_SERVER, imp_dbh->errhp, status
+    );
+    if(status != OCI_SUCCESS)
+        return oci_error(ctrl->dbh, imp_dbh->errhp, status, "Server get");
+    OCIAttrGet_log_stat(
+            imp_dbh, imp_dbh->svchp, OCI_HTYPE_SVCCTX, &imp_dbh->seshp, NULL,
+            OCI_ATTR_SESSION, imp_dbh->errhp, status
+    );
+    if(status != OCI_SUCCESS)
+        return oci_error(ctrl->dbh, imp_dbh->errhp, status, "Session get");
+
+    return 1;
+}
+/*}}}*/
+#endif
+
+#if defined(USE_ITHREADS)
+static int _cnx_establish
+#else
+int cnx_establish
+#endif
+(pTHX_ dblogin_info_t * ctrl)
+{
+    imp_dbh_t * imp_dbh = ctrl->imp_dbh;
+    env_box_t * env_box;
+
+    if(!figure_out_charsets(aTHX_ ctrl)) return FALSE;
+    /* try to find existing OCIEnv */
+    env_box = find_env(ctrl->mode, imp_dbh->cset, imp_dbh->ncset);
+    if(env_box == NULL && !new_envhp_box(aTHX_ &env_box, ctrl)) return FALSE;
+
+    env_box->base.refs++;
+    imp_dbh->envhp = env_box->envhp;
+    imp_dbh->lock = &env_box->base;
+    imp_dbh->errhp = NULL;
+    imp_dbh->srvhp = NULL;
+    imp_dbh->svchp = NULL;
+    imp_dbh->seshp = NULL;
+    /* Now I want DESTROY to be called if something goes wrong */
+    DBIc_IMPSET_on(imp_dbh);
+#ifdef ORA_OCI_112
+    if(ctrl->pool_max != 0)
+        return session_from_pool(aTHX_ ctrl);
+#endif
+    return simple_connect(aTHX_ ctrl);
+}
+
+#if defined(USE_ITHREADS)
+int
+cnx_establish(pTHX_ dblogin_info_t * ctrl)
+{
+    int rv;
+    MUTEX_LOCK(&mng_lock);
+    rv = _cnx_establish(aTHX_ ctrl);
+    MUTEX_UNLOCK(&mng_lock);
+    return rv;
+}
+#endif
+
+/*dbd_dr_mng{{{
+ * this function is called every time new DR object is created.
+ * It is responsible for incrementing refs on all cached objects
+ */
+void
+dbd_dr_mng()
+{
+    llist_t * el;
+#if defined(USE_ITHREADS)
+    dTHX;
+    MUTEX_LOCK(&mng_lock);
+#endif
+    dr_instances++;
+    el = llist_left(&mng_list);
+    while(el != &mng_list)
+    {
+        box_t * base = (box_t *)el;
+#ifdef ORA_OCI_112
+        if(base->refs < 0) base->refs--;
+        else
+#endif
+        base->refs++;
+        el = llist_left(el);
+    }
+    if(mng_env == NULL)
+    {
+        sword status = OCIEnvNlsCreate(
+                &mng_env, OCI_DEFAULT,
+                0, NULL, NULL, NULL,
+                0, NULL, 0, 0
+        );
+        if(status == OCI_SUCCESS)
+            status=OCIHandleAlloc(
+                    mng_env,
+                    (dvoid**)&mng_err,
+                    OCI_HTYPE_ERROR,
+                    0, NULL
+            );
+        utf8_csid	   = OCINlsCharSetNameToId(mng_env, (void*)"UTF8");
+        al32utf8_csid  = OCINlsCharSetNameToId(mng_env, (void*)"AL32UTF8");
+        al16utf16_csid = OCINlsCharSetNameToId(mng_env, (void*)"AL16UTF16");
+    }
+#if defined(USE_ITHREADS)
+    MUTEX_UNLOCK(&mng_lock);
+#endif
+}
+/*}}}*/
+
+/* cnx_detach{{{*/
+void
+cnx_detach(pTHX_ imp_dbh_t * imp_dbh)
+{
+    /* Oracle will commit on an orderly disconnect.	*/
+    /* See DBI Driver.xst file for the DBI approach.	*/
+#ifdef ORA_OCI_112
+    if (imp_dbh->lock->refs < 0)
+    {
+        /* Release session, tagged for future retrieval. */
+        if(imp_dbh->session_tag != NULL)
+        {
+            STRLEN tlen;
+            char * tag = SvPV(imp_dbh->session_tag, tlen);
+            (void)OCISessionRelease(
+                    imp_dbh->svchp, imp_dbh->errhp,
+                    (OraText*)tag, (ub4)tlen, OCI_SESSRLS_RETAG
+            );
+            SvREFCNT_dec(imp_dbh->session_tag);
+            imp_dbh->session_tag = NULL;
+        }
+        else (void)OCISessionRelease(
+                imp_dbh->svchp, imp_dbh->errhp,
+                NULL, 0, OCI_DEFAULT
+        );
+        /* all handles are gone now */
+        imp_dbh->seshp = NULL;
+        imp_dbh->svchp = NULL;
+        imp_dbh->srvhp = NULL;
+    }
+    else {
+#endif
+        (void)OCISessionEnd(
+                imp_dbh->svchp, imp_dbh->errhp, imp_dbh->seshp, OCI_DEFAULT
+        );
+        (void)OCIServerDetach(imp_dbh->srvhp, imp_dbh->errhp, OCI_DEFAULT);
+#ifdef ORA_OCI_112
+    }
+#endif
+}/*}}}*/
+/*cnx_clean{{{*/
+void
+cnx_clean(pTHX_ imp_dbh_t * imp_dbh)
+{
+    if(imp_dbh->errhp != NULL)
+    {
+        (void)OCIHandleFree(imp_dbh->errhp, OCI_HTYPE_ERROR);
+        imp_dbh->errhp = NULL;
+    }
+    if(imp_dbh->seshp != NULL)
+    {
+        (void)OCIHandleFree(imp_dbh->seshp, OCI_HTYPE_SESSION);
+        imp_dbh->seshp = NULL;
+    }
+    if(imp_dbh->svchp != NULL)
+    {
+        (void)OCIHandleFree(imp_dbh->svchp, OCI_HTYPE_SVCCTX);
+        imp_dbh->svchp = NULL;
+    }
+    if(imp_dbh->srvhp != NULL)
+    {
+        (void)OCIHandleFree(imp_dbh->srvhp, OCI_HTYPE_SERVER);
+        imp_dbh->srvhp = NULL;
+    }
+
+#ifdef ORA_OCI_112
+    if(imp_dbh->lock->refs < 0)
+    {
+        imp_dbh->lock->refs++;
+        if(imp_dbh->lock->refs == 0)
+            release_pool(aTHX_ (pool_box_t *)imp_dbh->lock);
+    }
+    else
+    {
+#endif
+        imp_dbh->lock->refs--;
+        if(imp_dbh->lock->refs == 0)
+            release_env(aTHX_ (env_box_t *)imp_dbh->lock);
+#ifdef ORA_OCI_112
+    }
+#endif
+}/*}}}*/
+
+void
+cnx_drop_dr(pTHX_ imp_drh_t * imp_drh)
+{
+    llist_t * el;
+#if defined(USE_ITHREADS)
+    MUTEX_LOCK(&mng_lock);
+#endif
+    dr_instances--;
+    el = llist_left(&mng_list);
+    while(el != &mng_list)
+    {
+        box_t * base = (box_t *)el;
+#ifdef ORA_OCI_112
+        int is_pool = 0;
+        if(base->refs < 0)
+        {
+            base->refs++;
+            is_pool = 1;
+        }
+        else
+#endif
+        base->refs--;
+        el = llist_left(el);
+        if(base->refs == 0)
+        {
+#ifdef ORA_OCI_112
+            if(is_pool)
+                release_pool(aTHX_ (pool_box_t *)base);
+            else
+#endif
+                release_env(aTHX_ (env_box_t *)base);
+        }
+    }
+#if defined(USE_ITHREADS)
+    MUTEX_UNLOCK(&mng_lock);
+#endif
+}
+
+/* in vim: set foldmethod=marker: */

--- a/dbdcnx.c
+++ b/dbdcnx.c
@@ -67,62 +67,37 @@ struct llist_t{
     llist_t * right;
 };
 
-PERL_STATIC_INLINE int
-llist_empty(const llist_t * list)
-{
-    return list->left == list;
-}
+#define llist_empty(list) ((list)->left == (list))
 
-PERL_STATIC_INLINE void
-llist_init(llist_t *list)
-{
-    list->right = list->left = list;
-}
+#define llist_init(lst) do{\
+    llist_t * list = lst;\
+    list->right = list->left = list;\
+}while(0)
 
-PERL_STATIC_INLINE void
-llist_add(llist_t * left, llist_t * right)
-{
-    llist_t * old;
+#define llist_add(aleft, aright) do{\
+    llist_t * old;\
+    llist_t * left = aleft;\
+    llist_t * right = aright;\
+    old = left->right;\
+    left->right = right;\
+    old->left = right->left;\
+    right->left = left;\
+    old->left->right = old;\
+}while(0)
 
-    // first save the pointer from the left->rigth
-    old = left->right;
-
-    // now left->right shall point to right
-    left->right = right;
-
-    // now the old left pointer shall point to what the
-    // new right->left was pointing
-    old->left = right->left;
-
-    // now right->left shall contain the left
-    right->left = left;
-
-    // finally
-    old->left->right = old;
-}
-
-PERL_STATIC_INLINE void
-llist_drop(llist_t * el)
-{
-    if(llist_empty(el)) return;
-    el->left->right = el->right;
-    el->right->left = el->left;
-    llist_init(el);
-}
+#define llist_drop(ael) do{\
+    llist_t * el = ael;\
+    if(llist_empty(el)) return;\
+    el->left->right = el->right;\
+    el->right->left = el->left;\
+    llist_init(el);\
+}while(0)
 
 // this is pointer to the left element in chain
-PERL_STATIC_INLINE llist_t *
-llist_left(const llist_t * list)
-{
-    return list->left;
-}
+#define llist_left(list) (list)->left
 
 // this one is a pointer to the right element in chain
-PERL_STATIC_INLINE llist_t *
-llist_right(const llist_t *list)
-{
-    return list->right;
-}
+#define llist_right(list) (list)->right
 /* }}} */
 
 #if defined(USE_ITHREADS)

--- a/dbdcnx.c
+++ b/dbdcnx.c
@@ -528,6 +528,7 @@ cnx_pool_mode(pTHX_ SV * dbh, imp_dbh_t * imp_dbh, ub4 val)
         (void)oci_error(dbh, box->errhp, status, "OCIAttrSet POOL_GETMODE");
 }/*}}}*/
 /*cnx_pool_wait{{{*/
+#if OCI_MAJOR_VERSION > 18
 void
 cnx_pool_wait(pTHX_ SV * dbh, imp_dbh_t * imp_dbh, ub4 val)
 {
@@ -542,7 +543,9 @@ cnx_pool_wait(pTHX_ SV * dbh, imp_dbh_t * imp_dbh, ub4 val)
     );
     if(status != OCI_SUCCESS)
         (void)oci_error(dbh, box->errhp, status, "OCIAttrSet POOL_WAIT_TIMEOUT");
-}/*}}}*/
+}
+#endif
+/*}}}*/
 /*cnx_is_pooled_session{{{*/
 int
 cnx_is_pooled_session(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
@@ -568,6 +571,7 @@ cnx_get_pool_mode(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
     return 0;
 }/*}}}*/
 /*cnx_get_pool_wait{{{*/
+#if OCI_MAJOR_VERSION > 18
 int
 cnx_get_pool_wait(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
 {
@@ -584,7 +588,9 @@ cnx_get_pool_wait(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)
     if(status == OCI_SUCCESS) return (int)v;
     (void)oci_error(dbh, box->errhp, status, "OCIAttrGet POOL_WAIT_TIMEOUT");
     return 0;
-}/*}}}*/
+}
+#endif
+/*}}}*/
 /*cnx_get_pool_used{{{*/
 int
 cnx_get_pool_used(pTHX_ SV *dbh, imp_dbh_t * imp_dbh)

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -945,9 +945,11 @@ dbd_db_STORE_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv, SV *valuesv)
 	else if (kl==13 && strEQ(key, "ora_drcp_mode") ) {
 		cnx_pool_mode(aTHX_ dbh, imp_dbh, (ub4)SvIV(valuesv));
 	}
+#if OCI_MAJOR_VERSION > 18
 	else if (kl==13 && strEQ(key, "ora_drcp_wait") ) {
 		cnx_pool_wait(aTHX_ dbh, imp_dbh, (ub4)SvIV(valuesv));
 	}
+#endif
 	else if (kl==12 && strEQ(key, "ora_drcp_max") ) {
 		cnx_pool_max(aTHX_ dbh, imp_dbh, (ub4)SvIV(valuesv));
 	}
@@ -1115,9 +1117,11 @@ dbd_db_FETCH_attrib(SV *dbh, imp_dbh_t *imp_dbh, SV *keysv)
 	else if (kl==13 && strEQ(key, "ora_drcp_mode") ) {
 		retsv = newSViv(cnx_get_pool_mode(aTHX_ dbh, imp_dbh));
 	}
+#if OCI_MAJOR_VERSION > 18
 	else if (kl==13 && strEQ(key, "ora_drcp_wait") ) {
 		retsv = newSViv(cnx_get_pool_wait(aTHX_ dbh, imp_dbh));
 	}
+#endif
 	else if (kl==12 && strEQ(key, "ora_drcp_max") ) {
 		retsv = newSViv(cnx_get_pool_max(aTHX_ dbh, imp_dbh));
 	}

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -409,8 +409,10 @@ void ora_shared_release(pTHX_ SV * );
 int cnx_get_pool_mode(pTHX_ SV *, imp_dbh_t * );
 void cnx_pool_mode(pTHX_ SV * , imp_dbh_t * , ub4);
 
+#if OCI_MAJOR_VERSION > 18
 int cnx_get_pool_wait(pTHX_ SV *, imp_dbh_t * );
 void cnx_pool_wait(pTHX_ SV * , imp_dbh_t * , ub4);
+#endif
 
 int cnx_get_pool_used(pTHX_ SV *, imp_dbh_t * );
 

--- a/lib/DBD/Oracle.pm
+++ b/lib/DBD/Oracle.pm
@@ -1256,6 +1256,10 @@ SQL
 
 __END__
 
+=head1 NAME
+
+DBD::Oracle - Perl module for accessing Oracle
+
 
 =head1 SYNOPSIS
 
@@ -1670,7 +1674,11 @@ by setting this attribute to one of OCI_SPOOL_ATTRVAL_NOWAIT,
 OCI_SPOOL_ATTRVAL_FORCEGET, OCI_SPOOL_ATTRVAL_TIMEDWAIT. The latter one
 needs time in milliseconds, which is passed using attribute ora_drcp_wait.
 Default value is OCI_SPOOL_ATTRVAL_WAIT. These contants can be imported
-from DBD::Oracle.
+from DBD::Oracle. Important, functionality with OCI_SPOOL_ATTRVAL_TIMEDWAIT
+and OCI_SPOOL_ATTRVAL_NOWAIT was added by Oracle somewhere after version
+12, so to make it safe, DBD::Oracle supports it when compiled against
+OCI with Version > 18
+
 
 =head4 ora_drcp_tag
 

--- a/ocitrace.h
+++ b/ocitrace.h
@@ -48,8 +48,8 @@
 	stat =OCISessionRelease(svchp, errhp, tag, tagl, mode);\
 	(DBD_OCI_TRACEON(impdbh))                                       \
     ? PerlIO_printf(DBD_OCI_TRACEFP(impdbh),                             \
-						 "%sOCISessionRelease(svchp=%p,tag=\"%s\",mode=%u)=%s\n",\
-						 OciTp, svchp,tag,mode,oci_status_name(stat)),stat	\
+						 "%sOCISessionRelease(svchp=%p,mode=%u)=%s\n",\
+						 OciTp, svchp,mode,oci_status_name(stat)),stat	\
 	: stat
 
 #define OCISessionPoolDestroy_log_stat(impdbh, ph, errhp,stat )  \
@@ -63,8 +63,8 @@
 	stat =OCISessionGet(envhp, errhp, sh, ah,pn,pnl,tag,tagl,rettag,rettagl,found, OCI_SESSGET_SPOOL);\
 	(DBD_OCI_TRACEON(impdbh))                                          \
     ? PerlIO_printf(DBD_OCI_TRACEFP(impdbh),                           \
-					 "%sOCISessionGet(envhp=%p,sh=%p,ah=%p,pn=%p,pnl=%d,tag=\"%s\",found=%d)=%s\n",\
-					 OciTp, envhp,sh,ah,pn,pnl,tag,*found,oci_status_name(stat)),stat \
+					 "%sOCISessionGet(envhp=%p,sh=%p,ah=%p,pn=%p,pnl=%d,found=%d)=%s\n",\
+					 OciTp, envhp,sh,ah,pn,pnl,*found,oci_status_name(stat)),stat \
 	: stat
 
 #define OCISessionPoolCreate_log_stat(impdbh,envhp,errhp,ph,pn,pnl,dbn,dbl,sn,sm,si,un,unl,pw,pwl,mode,stat) \
@@ -321,12 +321,12 @@
 	OCIAttrGet_log_stat(imp_sth, stmhp, OCI_HTYPE_STMT,         \
 		(void*)(p1), (l), (a), imp_sth->errhp, stat)
 
-#define OCIAttrSet_log_stat(impxxh,th,ht,ah,s1,a,eh,stat)   \
+#define OCIAttrSet_log_stat(impxxh,th,ht,ah,s1,a,eh,stat)   do{\
 	stat=OCIAttrSet(th,ht,ah,s1,a,eh);				\
 	(DBD_OCI_TRACEON(impxxh)) ? PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
 		"%sAttrSet(%p,%s, %p,%lu,Attr=%s,%p)=%s\n",			\
 		OciTp, (void*)th,oci_hdtype_name(ht),(void *)ah,ul_t(s1),oci_attr_name(a),(void*)eh,	\
-		oci_status_name(stat)),stat : stat
+		oci_status_name(stat)),stat : stat; }while(0)
 
 #define OCIBindByName_log_stat(impsth,sh,bp,eh,p1,pl,v,vs,dt,in,al,rc,mx,cu,md,stat) \
 	stat=OCIBindByName(sh,bp,eh,p1,pl,v,vs,dt,in,al,rc,mx,cu,md);	\
@@ -369,17 +369,17 @@
 		(ub1)opt,(ub1)il,(ub1)ot,(void*)dh,				\
 		oci_status_name(stat)),stat : stat
 
-#define OCIDescriptorAlloc_ok(impxxh,envhp, p1, t)              \
+#define OCIDescriptorAlloc_ok(impxxh,envhp, p1, t)             do{ \
 	if (DBD_OCI_TRACEON(impxxh)) PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
 		"%sDescriptorAlloc(%p,%p,%s,0,0)\n",					\
 		OciTp,(void*)envhp,(void*)(p1),oci_hdtype_name(t));			\
 	if (OCIDescriptorAlloc((envhp), (void**)(p1), (t), 0, 0)==OCI_SUCCESS);	\
-	else croak("OCIDescriptorAlloc (type %d) failed",t)
+	else croak("OCIDescriptorAlloc (type %d) failed",t); }while(0)
 
-#define OCIDescriptorFree_log(impxxh,d,t)                       \
+#define OCIDescriptorFree_log(impxxh,d,t)                       do{\
 	if (DBD_OCI_TRACEON(impxxh)) PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
 		"%sDescriptorFree(%p,%s)\n", OciTp, (void*)d,oci_hdtype_name(t));	\
-	OCIDescriptorFree(d,t)
+	OCIDescriptorFree(d,t); }while(0)
 
 #define OCIEnvInit_log_stat(impdbh,ev,md,xm,um,stat)    \
 	stat=OCIEnvInit(ev,md,xm,um);					\
@@ -407,18 +407,18 @@
 	if (stat==OCI_SUCCESS) ;					\
 	else croak("OCIHandleAlloc(%s) failed",oci_hdtype_name(t))
 
-#define OCIHandleFree_log_stat(impxxh,hp,t,stat)    \
+#define OCIHandleFree_log_stat(impxxh,hp,t,stat)   do{ \
 	stat=OCIHandleFree(	(hp), (t));				\
-	(DBD_OCI_TRACEON(impxxh)) ? PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
+	if(DBD_OCI_TRACEON(impxxh)) PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
 		"%sHandleFree(%p,%s)=%s\n",OciTp,(void*)hp,oci_hdtype_name(t),		\
-		oci_status_name(stat)),stat : stat
+		oci_status_name(stat)); }while(0)
 
-#define OCILobGetLength_log_stat(impxxh,sh,eh,lh,l,stat)    \
+#define OCILobGetLength_log_stat(impxxh,sh,eh,lh,l,stat)  do{  \
 	stat=OCILobGetLength(sh,eh,lh,l);				\
 	(DBD_OCI_TRACEON(impxxh)) ? PerlIO_printf(DBD_OCI_TRACEFP(impxxh), \
 		"%sLobGetLength(%p,%p,%p,%p)=%s\n",				\
 		OciTp, (void*)sh,(void*)eh,(void*)lh,pul_t(l),		\
-		oci_status_name(stat)),stat : stat
+		oci_status_name(stat)),stat : stat; }while(0)
 
 
 #define OCILobGetChunkSize_log_stat(impdbh,sh,eh,lh,cs,stat)    \

--- a/t/15threads.t
+++ b/t/15threads.t
@@ -1,0 +1,102 @@
+#!perl
+
+use strict;
+use warnings;
+# This needs to be the very very first thing
+BEGIN { eval 'use threads; use threads::shared;' }
+use Config qw(%Config);
+use Test::More;
+use lib 't/lib';
+use DBDOracleTestLib qw/ oracle_test_dsn db_handle /;
+use DBD::Oracle qw(ora_shared_release);
+
+$| = 1;
+if ( !$Config{useithreads} || "$]" < 5.008 ) {
+    plan skip_all => "this $^O perl $] not configured to support iThreads";
+    exit(0);
+}
+if ( $DBI::VERSION <= 1.601 ) {
+    plan skip_all => 'DBI version '
+      . $DBI::VERSION
+      . ' does not support iThreads. Use version 1.602 or later.';
+    exit(0);
+}
+my $dbh    = db_handle( { PrintError => 0 } );
+
+if ($dbh) {
+    $dbh->disconnect;
+}
+else {
+    plan skip_all => 'Unable to connect to Oracle';
+}
+my $last_session : shared;
+my $holder : shared;
+
+for my $i ( 0 .. 4 ) {
+    threads->create(
+        sub {
+            my $dbh    = db_handle( { ora_dbh_share => \$holder, PrintError => 0 } );
+            if($dbh)
+            {
+                my $session = session_id($dbh);
+
+                if ( $i > 0 ) {
+                    is $session, $last_session,
+                      "session $i matches previous session";
+                }
+                else {
+                    ok $session, "session $i created",;
+                }
+
+                $last_session = $session;
+                $dbh->disconnect();
+            }
+            else
+            {
+                ok 0, "no connection " . $DBI::errstr;
+            }
+        }
+    )->join;
+}
+ora_shared_release($holder);
+
+# now the same, but let shared variable be destroyed
+threads->create(
+    sub {
+        my $other : shared;
+            for my $i ( 0 .. 4 ) {
+                threads->create(
+                    sub {
+                        my $dbh    = db_handle( { ora_dbh_share => \$other, PrintError => 0 } );
+                        if($dbh)
+                        {
+                            my $session = session_id($dbh);
+
+                            if ( $i > 0 ) {
+                                is $session, $last_session,
+                                  "session $i matches previous session";
+                            }
+                            else {
+                                ok $session, "session $i created",;
+                            }
+
+                            $last_session = $session;
+                            $dbh->disconnect();
+                        }
+                        else
+                        {
+                            ok 0, "no connection " . $DBI::errstr;
+                        }
+                    }
+                )->join;
+            }
+        ora_shared_release($other);
+    }
+)->join;
+done_testing;
+
+sub session_id {
+    my $dbh = shift;
+    my ($s) = $dbh->selectrow_array("select userenv('sid') from dual");
+    return $s;
+}

--- a/t/16cached.t
+++ b/t/16cached.t
@@ -1,0 +1,30 @@
+#!perl
+#written by Andrey A Voropaev (avorop@mail.ru)
+
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+use FindBin qw($Bin);
+use lib 't/lib';
+use DBDOracleTestLib qw/ db_handle /;
+
+my $dbh;
+$| = 1;
+SKIP: {
+    $dbh = db_handle();
+
+    #  $dbh->{PrintError} = 1;
+    plan skip_all => 'Unable to connect to Oracle' unless $dbh;
+
+    note("Testing multiple cached connections...\n");
+
+    plan tests => 1;
+
+    system("perl -MExtUtils::testlib $Bin/cache2.pl");
+    ok($? == 0, "clean termination with multiple cached connections");
+}
+
+__END__
+

--- a/t/16drcp.t
+++ b/t/16drcp.t
@@ -1,0 +1,112 @@
+#!perl
+
+use strict;
+use warnings;
+# This needs to be the very very first thing
+BEGIN { eval 'use threads; use threads::shared;' }
+
+$| = 1;
+
+## ----------------------------------------------------------------------------
+## 16drcp.t
+## By Andrey A. Voropaev
+## ----------------------------------------------------------------------------
+use lib 't/lib';
+use DBDOracleTestLib qw/ oracle_test_dsn db_handle /;
+use DBD::Oracle qw(OCI_SPOOL_ATTRVAL_NOWAIT);
+use DBI;
+use Test::More;
+
+{
+    my $dbh    = db_handle( { PrintError => 0 } );
+
+    if ($dbh) {
+        $dbh->disconnect;
+    }
+    else {
+        plan skip_all => 'Unable to connect to Oracle';
+    }
+}
+
+{
+    my $dbh   = db_handle( { ora_drcp=>1, ora_drcp_max => 2, PrintError => 0 } );
+    ok defined $dbh, 'first connection from pool';
+    my $dbh1   = db_handle( { ora_drcp=>1, PrintError => 0 } );
+    ok defined $dbh1, 'second connection from pool';
+    is $dbh->{ora_drcp_used}, 2, 'count of used connections is 2';
+    $dbh->{ora_drcp_mode} = OCI_SPOOL_ATTRVAL_NOWAIT;
+    my $dbh2   = db_handle( { ora_drcp=>1, PrintError => 0 } );
+    ok !defined $dbh2, 'third connection from pool not allowed';
+
+    $dbh->do(q(alter session set NLS_DATE_FORMAT='yyyy.mm.dd'));
+    $dbh->{ora_drcp_tag} = 's1';
+    $dbh1->do(q(alter session set NLS_DATE_FORMAT='dd.mm.yyyy'));
+    $dbh1->{ora_drcp_tag} = 's2';
+
+    $dbh->disconnect();
+    $dbh1->disconnect();
+}
+{
+    my $dbh   = db_handle( { ora_drcp=>1, ora_drcp_tag=> 's1', PrintError => 0 } );
+    if ($dbh) {
+        my $found_tag = $dbh->{ora_drcp_tag};
+        ok((defined $found_tag && $found_tag eq 's1'), 's1 session from pool');
+        my $sth = $dbh->prepare('select sysdate from dual');
+        $sth->execute();
+        my $x = $sth->fetchall_arrayref();
+        ok($x->[0][0] =~ /^\d{4}\.\d\d\.\d\d$/, "date in format yyyy.mm.dd");
+        $dbh->disconnect();
+    }
+    else {
+        ok 0, 'finding session s1';
+    }
+}
+{
+    my $dbh   = db_handle( { ora_drcp=>1, ora_drcp_tag=> 's2', PrintError => 0 } );
+    if ($dbh) {
+        my $found_tag = $dbh->{ora_drcp_tag};
+        ok((defined $found_tag && $found_tag eq 's2'), 's2 session from pool');
+        my $sth = $dbh->prepare('select sysdate from dual');
+        $sth->execute();
+        my $x = $sth->fetchall_arrayref();
+        ok($x->[0][0] =~ /^\d\d\.\d\d\.\d{4}$/, "date in format dd.mm.yyyy");
+        $dbh->disconnect();
+    }
+    else {
+        ok 0, 'finding session s2';
+    }
+}
+
+eval{
+    my @sts : shared;;
+    my $th1 = threads->create(
+        sub{ chk('s1', qr(\d{4}\.\d\d\.\d\d), $sts[0]) }
+    );
+    my $th2 = threads->create(
+        sub {chk('s2', qr(\d\d\.\d\d\.\d{4}), $sts[1]) }
+    );
+    $th1->join();
+    $th2->join();
+    ok($sts[0], 'first thread');
+    ok($sts[1], 'second thread');
+};
+
+done_testing;
+
+sub chk
+{
+    my $tag = shift;
+    my $p = shift;
+    my $dbh   = db_handle( { ora_drcp=>1, ora_drcp_tag=> $tag, PrintError => 0 } );
+    if ($dbh) {
+        my $found_tag = $dbh->{ora_drcp_tag};
+        my $sth = $dbh->prepare('select sysdate from dual');
+        $sth->execute();
+        my $x = $sth->fetchall_arrayref();
+        $_[0] = $found_tag eq $tag && $x->[0][0] =~ /^$p$/;
+        $dbh->disconnect();
+    }
+    else {
+        $_[0] = 0;
+    }
+}

--- a/t/22cset.t
+++ b/t/22cset.t
@@ -1,0 +1,125 @@
+#!perl
+#written by Andrey A Voropaev (avorop@mail.ru)
+
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+use DBD::Oracle qw(ORA_OCI);
+use Encode;
+use lib 't/lib';
+use DBDOracleTestLib qw/ db_handle drop_table table force_drop_table /;
+
+my $dbh1;
+my $dbh2;
+$| = 1;
+SKIP: {
+    plan skip_all =>
+      'Unable to run multiple cset test, perl version is less than 5.6'
+      unless ( $] >= 5.006 );
+
+    $dbh1 = db_handle({
+        RaiseError => 0,
+        PrintError => 0,
+        AutoCommit => 1,
+        ora_charset => 'WE8MSWIN1252',
+    });
+
+    plan skip_all => 'Unable to connect to Oracle' unless $dbh1;
+
+    plan skip_all => 'Oracle charset tests unreliable for Oracle 8 client'
+      if ORA_OCI() < 9.0 and !$ENV{DBD_ALL_TESTS};
+
+    my $h = $dbh1->ora_nls_parameters();
+    my $chs = $h->{NLS_CHARACTERSET};
+    if($chs ne 'WE8MSWIN1252' && $chs ne 'WE8ISO8859P1' && $chs !~ /^AL[13]/)
+    {
+        plan skip_all => 'Oracle uses incompatible charset';
+    }
+    note("Testing multiple connections with different charsets...\n");
+
+    $dbh2 = db_handle({
+        RaiseError => 0,
+        PrintError => 0,
+        AutoCommit => 1,
+        ora_charset => 'AL32UTF8',
+    });
+
+    my $testcount = 3;
+
+    plan tests => $testcount;
+
+    my $tname = table();
+    force_drop_table($dbh1);
+    $dbh1->do(
+        qq{create table $tname (idx number, txt varchar2(50))}
+    );
+    die "Failed to create test table\n" if($dbh1->err);
+
+    my $sth = $dbh1->prepare(
+        qq{insert into $tname (idx, txt) values(?, ?)}
+    );
+    my $utf8_txt = 'äöüÜÖÄ';
+    my $x = $utf8_txt;
+    Encode::from_to($x, 'UTF-8', 'Latin1');
+    $sth->execute(1, $x);
+
+    $sth = $dbh1->prepare(
+        qq{select txt from $tname where idx=1}
+    );
+    $sth->execute();
+    my $r = $sth->fetchall_arrayref();
+    ok(must_be_latin1($r, $utf8_txt), "Latin1 support");
+
+    $sth = $dbh2->prepare(
+        qq{insert into $tname (idx, txt) values(?, ?)}
+    );
+    # insert bytes
+    $x = $utf8_txt;
+    $sth->execute(2, $x);
+    # insert characters
+    $x = $utf8_txt;
+    $sth->execute(3, Encode::decode('UTF-8', $x));
+
+    $sth = $dbh2->prepare(
+        qq{select txt from $tname where idx=?}
+    );
+    $sth->execute(2);
+    $r = $sth->fetchall_arrayref();
+    ok(must_be_utf8($r, $utf8_txt), "UTF-8 as bytes");
+    $sth->execute(3);
+    $r = $sth->fetchall_arrayref();
+    ok(must_be_utf8($r, $utf8_txt), "UTF-8 as characters");
+}
+
+sub must_be_latin1
+{
+    my $r = shift;
+    return unless @$r == 1;
+    my $x = $r->[0][0];
+    # it shouldn't be encoded
+    return if Encode::is_utf8($x);
+    Encode::from_to($x, 'Latin1', 'UTF-8');
+    return $x eq $_[0];
+}
+
+sub must_be_utf8
+{
+    my $r = shift;
+    return unless @$r == 1;
+    my $x = $r->[0][0];
+    # it should be encoded
+    return unless Encode::is_utf8($x);
+    return Encode::encode('UTF-8', $x) eq $_[0];
+}
+
+
+END {
+    eval {
+        drop_table($dbh1)
+    };
+}
+
+__END__
+

--- a/t/25plsql.t
+++ b/t/25plsql.t
@@ -331,7 +331,7 @@ SKIP: {
    # Also see http://www.mail-archive.com/dbi-users@perl.org/msg18835.html
 
    # Known bad OCI versions
-   my @bad_oci_vers = (9.2, 18.3, 18.5, 19.6, 19.9, 19.13, 21.4, 21.5);
+   my @bad_oci_vers = (9.2, 18.3, 18.5, 19.6, 19.9, 19.13, 21.3, 21.4, 21.5);
 
    skip 'Client version is known to have issue', 4
      if grep { $_ == DBD::Oracle::ORA_OCI() } @bad_oci_vers;

--- a/t/25plsql.t
+++ b/t/25plsql.t
@@ -331,10 +331,8 @@ SKIP: {
    # Also see http://www.mail-archive.com/dbi-users@perl.org/msg18835.html
 
    # Known bad OCI versions
-   my @bad_oci_vers = (9.2, 18.3, 18.5, 19.6, 19.9, 19.13, 21.3, 21.4, 21.5);
-
    skip 'Client version is known to have issue', 4
-     if grep { $_ == DBD::Oracle::ORA_OCI() } @bad_oci_vers;
+     if DBD::Oracle::ORA_OCI() > 18.0;
 
    my $sth = $dbh->prepare(
       q(

--- a/t/38taf.t
+++ b/t/38taf.t
@@ -22,10 +22,8 @@ $dbh->disconnect;
 
 if ( !$dbh->ora_can_taf ) {
 
-    eval {
-        $dbh = db_handle( { ora_taf_function => 'taf' } );
-    };
-    my $ev = $@;
+    $dbh = db_handle( { PrintError => 0, RaiseError => 0, ora_taf_function => 'taf' } );
+    my $ev = $dbh->errstr;
     like( $ev, qr/You are attempting to enable TAF/, "'$ev' (expected)" );
 }
 else {

--- a/t/58object.t
+++ b/t/58object.t
@@ -13,7 +13,14 @@ use Test::More;
 
 $| = 1;
 
-$ENV{NLS_DATE_FORMAT} = 'YYYY-MM-DD"T"HH24:MI:SS';
+if($^O eq 'cygwin')
+{
+    DBD::Oracle::ora_cygwin_set_env('NLS_DATE_FORMAT', 'YYYY-MM-DD"T"HH24:MI:SS');
+}
+else
+{
+    $ENV{NLS_DATE_FORMAT} = 'YYYY-MM-DD"T"HH24:MI:SS';
+}
 
 # create a database handle
 my $dbh = eval{ db_handle( {

--- a/t/cache2.pl
+++ b/t/cache2.pl
@@ -1,0 +1,63 @@
+#!perl
+#written by Andrey A Voropaev (avorop@mail.ru)
+
+use strict;
+
+use DBI;
+
+tst1();
+tst2();
+tst1();
+tst2();
+
+sub tst1
+{
+    my $dbh = db_handle({
+            RaiseError => 0,
+            PrintError => 0,
+            AutoCommit => 1,
+            ora_charset => 'WE8MSWIN1252',
+        });
+    my $sth = $dbh->prepare(
+        q{ select 1 from dual }
+    );
+    $sth->execute();
+    my $r = $sth->fetchall_arrayref();
+}
+
+sub tst2
+{
+    my $dbh = db_handle({
+            RaiseError => 0,
+            PrintError => 0,
+            AutoCommit => 1,
+            ora_charset => 'AL32UTF8',
+        });
+    my $sth = $dbh->prepare(
+        q{ select 2 from dual }
+    );
+    $sth->execute();
+    my $r = $sth->fetchall_arrayref();
+}
+
+
+sub oracle_test_dsn {
+    my ( $default, $dsn ) = ( 'dbi:Oracle:', $ENV{ORACLE_DSN} );
+
+    $dsn ||= $ENV{DBI_DSN}
+      if $ENV{DBI_DSN} && ( $ENV{DBI_DSN} =~ m/^$default/io );
+    $dsn ||= $default;
+
+    return $dsn;
+}
+
+sub db_handle {
+
+    my $p = shift;
+    my $dsn    = oracle_test_dsn();
+    my $dbuser = $ENV{ORACLE_USERID} || 'scott/tiger';
+    my $dbh    = DBI->connect_cached( $dsn, $dbuser, '', $p );
+    return $dbh
+
+}
+


### PR DESCRIPTION
This changes the way things are done during login6 (connect). In
particular:

1. OCIEnv is cached based on character sets and mode. One copy
is used in all threads (so OCI_THREADED is important!)

2. There are no more global variables for character sets. So each
connection uses exactly what is specified at connection time. Thus
option ora_envhp is removed.

3. Improved support for DRCP. Now the pools are independent from
threads. The pool is defined by DSN and UID. No more leaking of
connections or pools. When last imp_drh goes away the pools
are released. It is now also possible to tag sessions in addition
to using connection_class (the latter works only with DRCP).

4. Reauthenticate now keeps old session as long as possible, so
if new identity is wrong, then old session stays intact.

5. Support for using shared variables is also improved. There is
now additional function ora_shared_release that cleans up shared
connection, when it is not needed anymore. Though it is still
cleaner to used DRCP. No more handles are leaking.

6. Support for imp_take is improved. No handles are leaking.
But it is cleaner to use DRCP.

7. Small fixes for compilation and handling of attributes.

8. And of course, the SEGV associated with incorrect cleanup of handles is fixed