### PR TITLE
specify resources metadata explicitly in dist.ini

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -60,15 +60,6 @@ my %opts = (
        build_requires => {"DBI" => '1.623',
                           "ExtUtils::MakeMaker" => 0,
                           "Test::Simple" => '0.90'},
-       resources => {
-           bugtracker => { web => 'https://github.com/perl5-dbi/DBD-Oracle/issues'},
-           homepage => 'https://metacpan.org/pod/DBD::Oracle',
-           repository => {
-               type => 'git',
-               url => 'git://github.com/perl5-dbi/DBD-Oracle.git',
-               web => 'http://github.com/perl5-dbi/DBD-Oracle',
-           },
-       },
     },
 );
 my $eumm = $ExtUtils::MakeMaker::VERSION;

--- a/dist.ini
+++ b/dist.ini
@@ -20,10 +20,12 @@ version = 1.83
 [Git::Contributors]
 [ContributorsFile]
 [InstallGuide]
-[GithubMeta]
-; fork = 1
-bugs = 1
-; remote = upstream
+[MetaResources]
+homepage          = https://metacpan.org/pod/DBD::Oracle
+bugtracker.web    = https://github.com/perl5-dbi/DBD-Oracle/issues
+repository.url    = https://github.com/perl5-dbi/DBD-Oracle.git
+repository.web    = https://github.com/perl5-dbi/DBD-Oracle
+repository.type   = git
 
 [MetaYAML]
 [PodWeaver]


### PR DESCRIPTION
The latest stable release of DBD::Oracle listed the wrong bug tracker and repository because it was released from a fork, and the [GithubMeta] plugin used that fork to set the metadata.

Remove that plugin, and instead specify the bug tracker and repository explicitly.