### PR TITLE
Makefile.PL: help ora_libdir find ORACLE_HOME on Gentoo

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1798,7 +1798,7 @@ sub symbol_search {
         }
         close main::MK_PM or die "Error closing mk.pm: $!\n";
 
-        foreach (qw(mk.pm Oracle.h dbdimp.h ocitrace.h)) {
+        foreach (qw(mk.pm Oracle.h dbdimp.h dbivport.h ocitrace.h)) {
             $self->{PM}->{$_} = '$(INST_ARCHAUTODIR)/'.$_;
         }
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1124,14 +1124,15 @@ sub perl_is_64bit {
     return defined $Config{use64bitall} ;
 }
 sub ora_libdir {
-    my $libdir = 'lib' ;
+    my $libdir = 'lib';
     if ( $client_version >= 9 ) {
         $libdir = 'lib32' if ! perl_is_64bit() and -d "$OH/lib32";
+        $libdir = 'lib64' if perl_is_64bit() and -d "$OH/lib64";
+        # Solaris OIC 12+ from pkg
         $libdir = 'lib/64' if perl_is_64bit() and -d "$OH/lib/64";
-           # Solaris OIC 12+ from pkg
     }
     else {
-        $libdir = 'lib64' if   perl_is_64bit() and -d "$OH/lib64";
+        $libdir = 'lib64' if perl_is_64bit() and -d "$OH/lib64";
     }
 
     return $libdir;


### PR DESCRIPTION
On Gentoo, for better or worse, we install oracle-instantclient on 64-bit systems to /usr/lib64/oracle/client/ with:
* /usr/lib64/oracle/client/lib for 32-bit libraries (multilib)
* /usr/lib64/oracle/client/lib64 for native 64-bit libraries

Adapt the logic to handle lib64 if it exists and we're using a 64-bit Perl.

(And fix some whitespace while at it.)