### PR TITLE
Changing 'return' to block statement, fixing a problem created while transforming inline function to macro

### DIFF
--- a/dbdcnx.c
+++ b/dbdcnx.c
@@ -87,10 +87,11 @@ struct llist_t{
 
 #define llist_drop(ael) do{\
     llist_t * el = ael;\
-    if(llist_empty(el)) return;\
-    el->left->right = el->right;\
-    el->right->left = el->left;\
-    llist_init(el);\
+    if(!llist_empty(el)) {\
+        el->left->right = el->right;\
+        el->right->left = el->left;\
+        llist_init(el);\
+    } \
 }while(0)
 
 // this is pointer to the left element in chain


### PR DESCRIPTION
The transformation of inline function llist_drop to macro llist_drop introduced a bug: the return statement was meant to leave to inline function, but after the transformation it leaves the function that calls the macro.

Also if your compiler is strict enough, it won't compile, as the macro is called from both 'void' and 'non-void' functions.

The fix is changing the code, from if (cond) return; rest; to if (!cond) { rest; }
