### PR TITLE
Makefile.PL fix for missing Test::NoWarnings build requirement

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -50,5 +50,6 @@ jobs:
       - run: sudo -E maint/scripts/03_install_oracle_instantclient_rpm.bash
       - run: . /etc/profile
       - run: perl -V
-      - run: cpanm DBI Test::NoWarnings
+      - run: cpanm DBI # DBI must be installed before we can build a DBD.
+      - run: cpanm --installdeps .
       - run: perl Makefile.PL && make && make test

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -45,6 +45,7 @@ my %opts = (
     NAME => 'DBD::Oracle',
     VERSION_FROM => 'lib/DBD/Oracle.pm',
     PREREQ_PM => { "Test::Simple" => 0.90, # actually Test::More pkg in T::S dist
+                   "Test::NoWarnings" => 1.00,
                    "DBI"          => 1.623},
     OBJECT => '$(O_FILES)',
     DEFINE => '',
@@ -59,20 +60,16 @@ my %opts = (
        configure_requires => { "DBI" => '1.623' },
        build_requires => {"DBI" => '1.623',
                           "ExtUtils::MakeMaker" => 0,
-                          "Test::Simple" => '0.90'},
+                          "Test::Simple" => '0.90',
+                          "Test::NoWarnings" => "1.00"},
     },
 );
-my $eumm = $ExtUtils::MakeMaker::VERSION;
-$eumm =~ tr/_//d;
 
-if ($eumm >= 5.43) {
-    $opts{AUTHOR} = 'Tim Bunce (dbi-users@perl.org)';
-    $opts{ABSTRACT_FROM} = 'lib/DBD/Oracle.pm';
-    $opts{PREREQ_PM} = { DBI => 1.623 };
-    $opts{CAPI} = 'TRUE' if $Config{archname} =~ /-object\b/i;
-}
+$opts{AUTHOR} = 'Tim Bunce (dbi-users@perl.org)';
+$opts{ABSTRACT_FROM} = 'lib/DBD/Oracle.pm';
+$opts{CAPI} = 'TRUE' if $Config{archname} =~ /-object\b/i;
 
-$opts{LICENSE} = 'perl' if $eumm >= 6.3002;
+$opts{LICENSE} = 'perl';
 $opts{CCFLAGS} = "-P $Config{ccflags}" if $Config{cc} eq 'bcc32';  # force C++
 $opts{LINKTYPE} = 'static' if $Config{dlsrc} =~ /dl_none/;
 


### PR DESCRIPTION
I added Test::NoWarnings but it still wasn't installing the module. Turns out there was an ancient condition that modified PREREQ_PM. I removed this since it will probably never be true for anybody again. Updated GHA accordingly.

This fixes #175.