### PR TITLE
Makefile.PL: help to find linking libraries on Gentoo

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -374,7 +374,7 @@ elsif (($^O eq 'MSWin32') or ($^O =~ /cygwin/i)) {
 # --- UNIX Variants ---
 
 elsif ($::opt_l || !defined $mkfile and # use -l to enable this direct-link approach
-        @_=grep { m:/lib(cl(ie)?ntsh|oracle).\w+$:o } <$OH/lib/lib*>
+        @_=grep { m:/lib(cl(ie)?ntsh|oracle).\w+$:o } <$OH/lib{,64}/lib*>
     ) {
     # --- the simple modern way ---
     foreach(@_) { s:\Q$OH/lib/::g }


### PR DESCRIPTION
On Gentoo we install oracle-instantclient libraries in /usr/lib64/oracle/client/lib64 on 64-bit systems and in /usr/lib/oracle/client/lib on 32-bit systems.

This was done because in a 64-bit system with multilib, both 32-bit libraries (/usr/lib64/oracle/client/lib) and 64-bit libraries (/usr/lib64/oracle/client/lib64) were installed. For now, this specification is disabled because it is rare to have the same version of oracle instantclient for both 32-bit and 64-bit.