### PR TITLE
Remove outdated #ifdefs

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -766,7 +766,6 @@ int dbd_st_bind_col(SV *sth, imp_sth_t *imp_sth, SV *col, SV *ref, IV type, SV *
         imp_sth->fbh[field-1].bind_flags = 0; /* default to none */
     }
 
-#if DBIXS_REVISION >= 13590
 	/* DBIXS 13590 added StrictlyTyped and DiscardString attributes */
 	if (attribs) {
 		HV *attr_hash;
@@ -790,7 +789,6 @@ int dbd_st_bind_col(SV *sth, imp_sth_t *imp_sth, SV *col, SV *ref, IV type, SV *
 			imp_sth->fbh[field-1].bind_flags |= DBIstcf_DISCARD_STRING;
 		}
 	}
-#endif  /* DBIXS_REVISION >= 13590 */
 	return 1;
 }
 

--- a/oci8.c
+++ b/oci8.c
@@ -4189,7 +4189,6 @@ dbd_st_fetch(SV *sth, imp_sth_t *imp_sth){
 							--datalen;
 					}
 					sv_setpvn(sv, p, (STRLEN)datalen);
-#if DBIXS_REVISION > 13590
 		/* If a bind type was specified we use DBI's sql_type_cast
 			to cast it - currently only number types are handled */
 					if ((fbh->req_type != 0) && (fbh->bind_flags != 0)) {
@@ -4219,7 +4218,6 @@ dbd_st_fetch(SV *sth, imp_sth_t *imp_sth){
 						}
 					}
 					else
-#endif /* DBISTATE_VERSION > 94 */
 					{
 						if (CSFORM_IMPLIES_UTF8(imp_dbh, fbh->csform) ){
 							SvUTF8_on(sv);


### PR DESCRIPTION
As the minimum required version of DBI is 1.623, these

when the versions stored in these variables change in DBI