### PR TITLE
Test cleanups & New SEGV forking test reproduction

### DIFF
--- a/t/90-segv-threads.t
+++ b/t/90-segv-threads.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 
-use 5.030003;
 use strict;
 use warnings;
 use Test::More;
@@ -202,6 +201,7 @@ use strict;
 use warnings;
 use threads;
 use threads::shared 1.51;
+use Thread::Queue;
 use Time::HiRes qw| usleep |;
 use DBI;
 use Test::More;

--- a/t/91-segv-fork.t
+++ b/t/91-segv-fork.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 
-use 5.030003;
 use strict;
 use warnings;
 use Time::HiRes qw| usleep |;

--- a/t/92-segv-fork.pl
+++ b/t/92-segv-fork.pl
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use lib 't/lib';
+use DBDOracleTestLib qw| db_handle |;
+use Time::HiRes qw| usleep |;
+
+our $VERSION = 0.01;
+
+## GOAL: Test for segfaults in parent processes receieving SIGCHLD
+##   An application I maintain, dispatces childern to perform work
+##   that the parent process does not have tie to perform. It has completed
+##   the work, needed, plces that work into a queeue, and the queue is used
+##   by the parent process dispatch the work by dispatcing child proceses.
+##   The parent reaps the children and launces new children as needed
+##   until the queue is empty. The parent process is a long running
+##   performng DB work it must itself perform.
+
+##  We dont have any real work here so we'll emulate the work by.
+##   This program is the child process. A test program that forks us
+##   will run this to emulate the work being dispatched.
+##
+##  1. Connecting to DB
+##  2. Read data.
+##  3. Pretending to do work for a random period of time in the range of 2-5 seconds
+##      (which approxily matches the time the actual tool I maintain takes to do work)
+##  4. Disconnect from DB
+##  5. Exit with a success exit code.
+##      The parent does not care if we succeeded or not, it just needs to know
+##      that we have completed the work and available for reaping.
+
+local $Data::Dumper::Indent = 1;
+local $Data::Dumper::Terse  = 1;
+
+my $job = @ARGV ? shift : 'DEFAULT-JOB';
+my $dbh = db_handle({ AutoCommit => 0, RaiseError => 0, PrintError => 1 });
+
+exit(1) unless $dbh;
+exit(2) unless $dbh->ping;
+
+my $sth = $dbh->prepare("SELECT '${job}: The Quick Brown Fox Jumped Over The Lazy Dogs Back' FROM DUAL");
+
+exit(3) unless $sth;
+exit(4) unless $sth->execute;
+
+my $row = $sth->fetchrow_arrayref;
+
+exit(5) unless $sth->finish;
+exit(6) unless scalar @ $row == 1;
+# printf "# [ %s ]\n", $row->[];
+
+my $usleep = int(rand(300000)) + 2000000; # 2-5 seconds
+# printf "# %02.2f seconds\n", $usleep / 1000000;
+usleep($usleep);
+
+exit(7) unless $dbh->disconnect;
+
+## Trigger OS into sending SIGCHLD to the parent process.
+exit(0);
+
+## vim: set ts=2 sw=2 expandtab number:
+## END

--- a/t/92-segv-fork.pl
+++ b/t/92-segv-fork.pl
@@ -9,26 +9,27 @@ use Time::HiRes qw| usleep |;
 our $VERSION = 0.01;
 
 ## GOAL: Test for segfaults in parent processes receieving SIGCHLD
-##   An application I maintain, dispatces childern to perform work
-##   that the parent process does not have tie to perform. It has completed
-##   the work, needed, plces that work into a queeue, and the queue is used
-##   by the parent process dispatch the work by dispatcing child proceses.
-##   The parent reaps the children and launces new children as needed
-##   until the queue is empty. The parent process is a long running
-##   performng DB work it must itself perform.
+##   An application I maintain, dispatches childern to perform work
+##   that the parent process does not have time to perform. It has completed
+##   the work it needed, places the remaing task into a queeue, and the queue is used
+##   by the parent process for dispatching child proceses.
+##   The parent reaps the children and launches new children as needed
+##   until the queue is empty. The parent process is long running
+##   performing DB work it must itself perform.
 
-##  We dont have any real work here so we'll emulate the work by.
+##  We dont have any real work here so we'll emulate the work.
 ##   This program is the child process. A test program that forks us
-##   will run this to emulate the work being dispatched.
+##   will run to emulate the work being dispatched.
 ##
 ##  1. Connecting to DB
 ##  2. Read data.
 ##  3. Pretending to do work for a random period of time in the range of 2-5 seconds
-##      (which approxily matches the time the actual tool I maintain takes to do work)
+##      (which approxily matches the time the actual tool I maintain takes to do the task)
 ##  4. Disconnect from DB
 ##  5. Exit with a success exit code.
 ##      The parent does not care if we succeeded or not, it just needs to know
 ##      that we have completed the work and available for reaping.
+##      allowing for another task to be dispatched.
 
 local $Data::Dumper::Indent = 1;
 local $Data::Dumper::Terse  = 1;

--- a/t/92-segv-fork.t
+++ b/t/92-segv-fork.t
@@ -1,0 +1,310 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Time::HiRes qw| usleep |;
+use Test::More;
+use Data::Dumper;
+
+local $Data::Dumper::Indent = 1;
+local $Data::Dumper::Terse  = 1;
+
+$ENV{DBD_ORACLE_DUMP} = 0;
+
+our $VERSION      = 0.1;
+our $VERBOSE      = 0;
+our $ORACLE_HOME  = $ENV{ORACLE_HOME};
+
+my $TEST_START = Time::HiRes::time();
+
+sub section
+{
+  my $msg = shift;
+  note '+ --------------------------------------------- +';
+  note " $msg";
+  note '+ --------------------------------------------- +';
+  return;
+}
+
+sub abort
+{
+  my $msg = shift;
+  printf STDERR "\n";
+  printf STDERR "# + --------------------------------------------- +\n";
+  printf STDERR "#   %s\n", $msg;
+  printf STDERR "# + --------------------------------------------- +\n";
+  printf STDERR "\n";
+  note sprintf 'Completed in %5.3fs', Time::HiRes::time() - $TEST_START;
+  done_testing();
+  exit 1;
+}
+
+## Noise hides real issues (if there are any)
+local $SIG{__WARN__} = sub { warn $_[0] unless $_[0] =~ m/^Subroutine/xi };
+
+PERL_NOTICE:
+{
+  note qx|perl -V|  if $VERBOSE;
+}
+
+ORACLE_READY:
+{
+  Child::Queue->do_connect( { PrintError => 0 } ) or plan skip_all => "Unable to connect to oracle\n";
+}
+
+QUEUE_BASICS:
+{
+  section 'QUEUE - BASICS';
+
+  my $queue = Child::Queue->new( -DEPTH => 8 );
+
+  is  $queue->depth,     8, 'Queue depth';
+  is  $queue->size,      0, 'Queue size';
+  is  $queue->running,   0, 'Queue running';
+  ok  $queue->isIdle,       'Queue is idle';
+  ok !$queue->isBusy,       'Queue is not busy';
+  ok  $queue->hasSlots,     'Queue has slots';
+  ok !$queue->isFull,       'Queue is not full';
+  ok  $queue->enqueue(1),   'Enqueue 1';
+  is  $queue->size,      1, 'Queue size';
+  ok  $queue->enqueue(2),   'Enqueue 2';
+  is  $queue->size,      2, 'Queue size';
+  is  $queue->running,   0, 'Queue running';
+  is  $queue->dequeue,   1, 'Dequeue 1';
+  is  $queue->size,      1, 'Queue size';
+  is  $queue->dequeue,   2, 'Dequeue 2';
+  is  $queue->size,      0, 'Queue size';
+  ok  $queue->isIdle,       'Queue is idle';
+  ok !$queue->isBusy,       'Queue is not busy';
+  ok  $queue->hasSlots,     'Queue has slots';
+}
+
+
+FORK_SEGV:
+{
+# last FORK_SEGV if 1;
+
+  section 'FORK - SEGV';
+
+  my $queue = Child::Queue->new( -DEPTH => 8 );
+  my $jobs  = 80;
+
+  is  $queue->depth,     8, 'Queue depth';
+  is  $queue->size,      0, 'Queue size';
+  is  $queue->running,   0, 'Queue running';
+  ok  $queue->isIdle,       'Queue is idle';
+  ok !$queue->isBusy,       'Queue is not busy';
+  ok  $queue->hasSlots,     'Queue has slots';
+  ok !$queue->isFull,       'Queue is not full';
+
+
+  for my $i ( 1 .. $jobs )
+  {
+    my $job = sprintf 'JOB-%03d', $i;
+    ok  $queue->enqueue($job),    'Enqueue ' . $job;
+  }
+
+  is  $queue->size,      $jobs,   'Queue size';
+  is  $queue->running,   0,       'Queue running - zero';
+
+  ok  $queue->startone($queue->dequeue), 'Start one child ->> 1';
+  is  $queue->size,     $jobs-1,  'Queue size verified';
+  ok  $queue->startone($queue->dequeue), 'Start one child ->> 2';
+  is  $queue->size,     $jobs-2,  'Queue size verified';
+  ok  $queue->run,                'queue->run - start -DEPTH children';
+  is  $queue->running, 8,         'Queue running - 8 children started';
+  ok  $queue->isFull,             'Queue is full';
+
+  # note Dumper($Child::Queue::WORKSET);
+
+  while ( $queue->isBusy )
+  {
+    usleep(50000);
+    $queue->run if $queue->hasSlots && $queue->size;
+    usleep(15000);
+  }
+
+  is  $queue->size,      0,       'Queue size - all jobs done';
+  is  $queue->running,   0,       'Queue running - zero';
+  ok  $queue->isIdle,       'Queue is idle';
+  ok !$queue->isBusy,       'Queue is not busy';
+  ok  $queue->hasSlots,     'Queue has slots';
+  ok !$queue->isFull,       'Queue is not full';
+}
+
+
+note sprintf 'Completed in %5.3fs', Time::HiRes::time() - $TEST_START;
+done_testing();
+
+
+## Children QUEUE
+
+package Child::Queue;
+
+use strict;
+use warnings;
+use Data::Dumper;
+use POSIX ":sys_wait_h";
+
+use lib 't/lib';
+use DBDOracleTestLib qw/ db_handle /;
+
+our $VERSION;
+our $VERBOSE;
+our $QUEUE;
+our $WORKSET;
+
+sub _SIG_CHLD
+{
+  my $pid = waitpid(-1, WNOHANG);
+  my $code = $? >> 8;
+ 
+  return unless $pid > 0;
+
+  if ( exists $WORKSET->{$pid} )
+  {
+    my $child = delete $WORKSET->{$pid};
+    my $results = $child->finish( $code );
+    printf "# Child %d finished with code %d\n", $pid, $results->{CODE};
+    print Dumper($results);
+  }
+  else
+  {
+    printf "# Child %d finished but not in workset", $pid;
+  }
+}
+
+BEGIN {
+  $VERSION  = 0.1;
+  $VERBOSE  = $main::VERBOSE || 0;
+  $QUEUE    = [];
+  $WORKSET  = {};  # PID => Child::Runner
+
+  $SIG{CHLD} = \&_SIG_CHLD;
+}
+
+sub new
+{
+  my $self = shift;
+  my $args = ref $_[0] ? shift : { @_ };
+  return bless $args, $self
+}
+
+sub depth     { return $_[0]->{-DEPTH} }
+sub isBusy    { return $_[0]->size > 0 || $_[0]->running > 0 }
+sub isIdle    { return ! $_[0]->isBusy }
+sub enqueue   { return push @ $QUEUE, pop }
+sub dequeue   { return shift @ $QUEUE }
+sub size      { return scalar @ $QUEUE }
+sub running   { return scalar keys % $WORKSET }
+sub isFull    { return $_[0]->running >= $_[0]->depth }
+sub hasSlots  { return ! $_[0]->isFull }
+
+sub do_connect
+{
+  shift if $_[0] && ( ref($_[0]) eq __PACKAGE__ || $_[0] eq __PACKAGE__ );
+  return db_handle(@_);
+}
+
+sub startone
+{
+  my $self = shift;
+  my $job  = shift;
+  my $child = Child::Runner->new($job);
+
+  ## Make sure it stays set????
+  # $SIG{CHLD} = \&_SIG_CHLD;
+
+  if ( ! defined $child->pid )
+  {
+    warn "Unable to start child for job: $job";
+    return;
+  }
+
+  $WORKSET->{$child->pid} = $child;
+}
+
+sub run
+{
+  my $self = shift;
+
+  while ( $self->hasSlots && $self->size )
+  {
+    $self->startone( $self->dequeue );
+
+    # my $job   = shift @ $QUEUE;
+    # my $child = Child::Runner->new($job);
+
+    # $WORKSET->{$child->pid} = $child;
+  }
+
+  return $self->isFull;
+}
+
+
+package Child::Runner;
+
+use strict;
+use warnings;
+use IPC::Open3 ();
+use Symbol 'gensym';
+
+sub new
+{
+  my $self = bless {}, shift;
+  my $job  = $self->job(shift);
+  my ( $in, $out, $err ) = (undef, undef, gensym);
+  my $pid = IPC::Open3::open3( $in, $out, $err, $^X, 't/92-segv-fork.pl', $job );
+
+  if ( ! defined $pid )
+  {
+    warn "Unable to fork: $!";
+    return;
+  }
+
+  $in->close or warn $! if $in;
+  $self->pid($pid);
+  $self->out($out);
+  $self->err($err);
+
+  return $self;
+}
+
+sub finish
+{
+  my $self  = shift;
+  my $code  = shift;
+  my $job   = $self->job;
+  my $pid   = $self->pid;
+  my $out   = $self->out;
+  my $err   = $self->err;
+  my $results = { -JOB  => $job, -PID  => $pid, -OUT  => [], -ERR  => [] };
+
+  if ( $self->pid )
+  {
+    my $O = $results->{-OUT};
+    my $E = $results->{-ERR};
+
+    while ( my $l = <$out> ) { chomp $l; push @ $O, $l }
+    while ( my $l = <$err> ) { chomp $l; push @ $E, $l }
+
+    close $out or warn "Unable to close out: $!";
+    close $err or warn "Unable to close err: $!";
+
+    # waitpid( $pid, 0 );
+    # $results->{ CODE } = $? >> 8;
+    $results->{ CODE } = $code;
+  }
+
+  return $results;
+}
+
+sub job     { return defined $_[1] ? $_[0]->{_JOB______} = $_[1] : $_[0]->{_JOB______} }
+sub pid     { return defined $_[1] ? $_[0]->{_PID______} = $_[1] : $_[0]->{_PID______} }
+sub out     { return defined $_[1] ? $_[0]->{_OUT______} = $_[1] : $_[0]->{_OUT______} }
+sub err     { return defined $_[1] ? $_[0]->{_ERR______} = $_[1] : $_[0]->{_ERR______} }
+
+1;
+
+## vim: number expandtab tabstop=2 shiftwidth=2
+## END


### PR DESCRIPTION
I have fixed all DBD::Oracle bugs (I could detect). I have this remaining
  SEGV fault within Perl itself.

ADDED: Additional forking test that reproduces SEGV
  within Perl 5.30.3+ using Oracle 19, 21 & 23. I've only tested
  with these combinations.

```
$ gdb $(which perl)
 -- snip --
(gdb) run t/92-segv-fork.t
 -- snip --

Thread 2 "perl" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff1cc4680 (LWP 9807)]
0x000055555562e610 in Perl_csighandler3 (sig=17, sip=0x0, uap=0x0) at mg.c:1601
1601	           (PL_signals & PERL_SIGNALS_UNSAFE_FLAG))
(gdb) list
1596	           sig == SIGSEGV ||
1597	#endif
1598	#ifdef SIGFPE
1599	           sig == SIGFPE ||
1600	#endif
1601	           (PL_signals & PERL_SIGNALS_UNSAFE_FLAG))
1602	        /* Call the perl level handler now--
1603	         * with risk we may be in malloc() or being destructed etc. */
1604	    {
1605	        if (PL_sighandlerp == Perl_sighandler)
(gdb) bt
    futex_word=0x5555563af118) at ./nptl/futex-internal.c:57
    at ./nptl/futex-internal.c:87
    abstime=abstime@entry=0x7ffff1cc3e00, private=private@entry=0) at ./nptl/futex-internal.c:139
    at ./nptl/pthread_cond_wait.c:503
(gdb)
```