### PR TITLE
Wrap skip_all in a BEGIN block (Closes: #219)

### DIFF
--- a/t/91-segv-fork.t
+++ b/t/91-segv-fork.t
@@ -5,10 +5,12 @@ use warnings;
 use Time::HiRes qw| usleep |;
 use Test::More;
 
-# Only run this test on Linux
-if ( $^O ne 'linux' ) {
-  plan skip_all => "91-segv-fork.t: skipping - test only runs on Linux (running on $^O)";
-  exit 0;
+BEGIN {
+  # Only run this test on Linux
+  if ($^O ne 'linux') {
+    plan skip_all => "91-segv-fork.t: skipping - test only runs on Linux (running on $^O)";
+    exit 0;
+  }
 }
 
 use Data::Dumper;


### PR DESCRIPTION
Thus making sure that the test is skipped before touching signals on unsupported platforms.