### PR TITLE
Remove $syslibs tweaking in Debian

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1127,9 +1127,6 @@ sub read_sysliblist {
        $linkwith =~ m/-lcl\b/ or
            $syslibs =~ s/\s*-lcl\b//g;
     }
-    if (lc(@Config{qw(myuname)}) =~ /debian/) {
-        $syslibs .= " -Wl,--no-as-needed -lnnz12 -lons -lclntshcore -lipc1 -lmql1";
-    }
     return $syslibs;
 }
 


### PR DESCRIPTION
It was needed with older versions of Oracle client to hardcode its library path into the binary, but newer Oracle client versions install `/etc/ld.so.conf.d/oracle-instantclient.conf` with the library path, so there's no need to add anything in `$syslibs` for Debian anymore.

Closes: #221